### PR TITLE
Support for multi-message integration tests

### DIFF
--- a/tests/dtda_test.py
+++ b/tests/dtda_test.py
@@ -1,9 +1,8 @@
-import unittest
 from kqml import KQMLList
 from bioagents.dtda import DTDA
 from bioagents.dtda import DTDA_Module
-from tests.util import *
-from tests.integration import _IntegrationTest, _FailureTest
+from tests.util import ekb_from_text, ekb_kstring_from_text, get_request
+from tests.integration import _IntegrationTest
 
 # DTDA unit tests
 
@@ -57,53 +56,45 @@ class _TestFindTargetDrug(_IntegrationTest):
     def __init__(self, *args):
         super(_TestFindTargetDrug, self).__init__(DTDA_Module)
 
-    def get_message(self):
+    def create_message(self):
         target = ekb_kstring_from_text(self.target)
         content = KQMLList('FIND-TARGET-DRUG')
         content.set('target', target)
         return get_request(content), content
 
-    def is_correct_response(self):
-        assert self.output.head() == 'SUCCESS', self.output
-        assert len(self.output.get('drugs')) == 9, self.output
-        return True
-
-    def give_feedback(self):
-        return None
+    def check_response_to_message(self, output):
+        assert output.head() == 'SUCCESS', output
+        assert len(output.get('drugs')) == 9, output
 
 
 class TestFindTargetDrug1(_TestFindTargetDrug):
     target = 'BRAF'
-    def is_correct_response(self):
-        assert self.output.head() == 'SUCCESS', self.output
-        assert len(self.output.get('drugs')) == 9, self.output
-        return True
+    def check_response_to_message(self, output):
+        assert output.head() == 'SUCCESS', output
+        assert len(output.get('drugs')) == 9, output
 
 
 class TestFindTargetDrug2(_TestFindTargetDrug):
     target = 'PAK4'
-    def is_correct_response(self):
-        assert self.output.head() == 'SUCCESS', self.output
-        assert len(self.output.get('drugs')) == 1, self.output
-        assert self.output.get('drugs')[0].gets('name') == 'PF-3758309'
-        assert self.output.get('drugs')[0].get('pubchem_id') == 25227462
-        return True
+    def check_response_to_message(self, output):
+        assert output.head() == 'SUCCESS', output
+        assert len(output.get('drugs')) == 1, output
+        assert output.get('drugs')[0].gets('name') == 'PF-3758309'
+        assert output.get('drugs')[0].get('pubchem_id') == 25227462
 
 
 class TestFindTargetDrug3(_TestFindTargetDrug):
     target = 'KRAS'
-    def is_correct_response(self):
-        assert self.output.head() == 'SUCCESS', self.output
-        assert len(self.output.get('drugs')) == 0, self.output
-        return True
+    def check_response_to_message(self, output):
+        assert output.head() == 'SUCCESS', output
+        assert len(output.get('drugs')) == 0, output
 
 
 class TestFindTargetDrug4(_TestFindTargetDrug):
     target = 'JAK2'
-    def is_correct_response(self):
-        assert self.output.head() == 'SUCCESS', self.output
-        assert len(self.output.get('drugs')) == 3, self.output
-        return True
+    def check_response_to_message(self, output):
+        assert output.head() == 'SUCCESS', output
+        assert len(output.get('drugs')) == 3, output
 
 
 # FIND-DRUG-TARGETS tests
@@ -112,29 +103,27 @@ class TestFindDrugTargets1(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
 
-    def get_message(self):
+    def create_message(self):
         drug = ekb_kstring_from_text('Vemurafenib')
         content = KQMLList('FIND-DRUG-TARGETS')
         content.set('drug', drug)
         return get_request(content), content
 
-    def is_correct_response(self):
-        assert self.output.head() == 'SUCCESS', self.output
-        assert len(self.output.get('targets')) == 1, self.output
-        assert self.output.get('targets')[0].gets('name') == 'BRAF'
-        return True
-
-    def give_feedback(self):
-        return None
+    def check_response_to_message(self, output):
+        assert output.head() == 'SUCCESS', output
+        assert len(output.get('targets')) == 1, output
+        assert output.get('targets')[0].gets('name') == 'BRAF'
 
 
 # IS-DRUG-TARGET tests
 
 class _TestIsDrugTarget(_IntegrationTest):
+    target = NotImplemented
+    drug = NotImplemented
     def __init__(self, *args):
         super(_TestIsDrugTarget, self).__init__(DTDA_Module)
 
-    def get_message(self):
+    def create_message(self):
         target = ekb_kstring_from_text(self.target)
         drug = ekb_kstring_from_text(self.drug)
         content = KQMLList('IS-DRUG-TARGET')
@@ -142,32 +131,26 @@ class _TestIsDrugTarget(_IntegrationTest):
         content.set('drug', drug)
         return get_request(content), content
 
-    def give_feedback(self):
-        return None
-
 class TestIsDrugTarget1(_TestIsDrugTarget):
     target = 'BRAF'
     drug = 'Vemurafenib'
-    def is_correct_response(self):
-        assert self.output.head() == 'SUCCESS', self.output
-        assert self.output.gets('is-target') == 'TRUE', self.output
-        return True
+    def check_response_to_message(self, output):
+        assert output.head() == 'SUCCESS', output
+        assert output.gets('is-target') == 'TRUE', output
 
 class TestIsDrugTarget2(_TestIsDrugTarget):
     target = 'BRAF'
     drug = 'dabrafenib'
-    def is_correct_response(self):
-        assert self.output.head() == 'SUCCESS', self.output
-        assert self.output.gets('is-target') == 'TRUE', self.output
-        return True
+    def check_response_to_message(self, output):
+        assert output.head() == 'SUCCESS', output
+        assert output.gets('is-target') == 'TRUE', output
 
 class TestIsDrugTarget3(_TestIsDrugTarget):
     target = 'KRAS'
     drug = 'dabrafenib'
-    def is_correct_response(self):
-        assert self.output.head() == 'SUCCESS', self.output
-        assert self.output.gets('is-target') == 'FALSE', self.output
-        return True
+    def check_response_to_message(self, output):
+        assert output.head() == 'SUCCESS', output
+        assert output.gets('is-target') == 'FALSE', output
 
 
 # FIND-DISEASE-TARGETS tests
@@ -175,59 +158,47 @@ class TestFindDiseaseTargets1(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
 
-    def get_message(self):
+    def create_message(self):
         disease = ekb_kstring_from_text('pancreatic cancer')
         content = KQMLList('FIND-DISEASE-TARGETS')
         content.set('disease', disease)
         return get_request(content), content
 
-    def is_correct_response(self):
-        assert self.output.head() == 'SUCCESS', self.output
-        protein = self.output.get('protein')
+    def check_response_to_message(self, output):
+        assert output.head() == 'SUCCESS', output
+        protein = output.get('protein')
         assert protein.get('name') == 'KRAS'
-        assert self.output.gets('prevalence') == '0.88'
-        assert self.output.gets('functional-effect') == 'ACTIVE'
-        return True
-
-    def give_feedback(self):
-        return None
+        assert output.gets('prevalence') == '0.88'
+        assert output.gets('functional-effect') == 'ACTIVE'
 
 class TestFindDiseaseTargets2(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
 
-    def get_message(self):
+    def create_message(self):
         disease = ekb_kstring_from_text('lung cancer')
         content = KQMLList('FIND-DISEASE-TARGETS')
         content.set('disease', disease)
         return get_request(content), content
 
-    def is_correct_response(self):
-        assert self.output.head() == 'SUCCESS', self.output
-        assert self.output.gets('prevalence') == '0.19'
-        assert self.output.gets('functional-effect') == 'ACTIVE'
-        return True
-
-    def give_feedback(self):
-        return None
+    def check_response_to_message(self, output):
+        assert output.head() == 'SUCCESS', output
+        assert output.gets('prevalence') == '0.19'
+        assert output.gets('functional-effect') == 'ACTIVE'
 
 class TestFindDiseaseTargets3(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
 
-    def get_message(self):
+    def create_message(self):
         disease = ekb_kstring_from_text('common cold')
         content = KQMLList('FIND-DISEASE-TARGETS')
         content.set('disease', disease)
         return get_request(content), content
 
-    def is_correct_response(self):
-        assert self.output.head() == 'FAILURE', self.output
-        assert self.output.gets('reason') == 'DISEASE_NOT_FOUND', self.output
-        return True
-
-    def give_feedback(self):
-        return None
+    def check_response_to_message(self, output):
+        assert output.head() == 'FAILURE', output
+        assert output.gets('reason') == 'DISEASE_NOT_FOUND', output
 
 
 # FIND-TREATMENT tests
@@ -235,59 +206,47 @@ class TestFindTreatment1(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
 
-    def get_message(self):
+    def create_message(self):
         disease = ekb_kstring_from_text('pancreatic cancer')
         content = KQMLList('FIND-TREATMENT')
         content.set('disease', disease)
         return get_request(content), content
 
-    def is_correct_response(self):
-        part1, part2 = self.output
+    def check_response_to_message(self, output):
+        part1, part2 = output
         assert part1.head() == 'SUCCESS', part1
         assert part2.head() == 'SUCCESS', part2
         assert part1.gets('prevalence') == '0.88', part1.get('prevalence')
         assert len(part2.get('drugs')) == 0
-        return True
-
-    def give_feedback(self):
-        return None
 
 class TestFindTreatment2(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
 
-    def get_message(self):
+    def create_message(self):
         disease = ekb_kstring_from_text('lung cancer')
         content = KQMLList('FIND-TREATMENT')
         content.set('disease', disease)
         return get_request(content), content
 
-    def is_correct_response(self):
-        part1, part2 = self.output
+    def check_response_to_message(self, output):
+        part1, part2 = output
         assert part1.head() == 'SUCCESS', part1
         assert part2.head() == 'SUCCESS', part2
         assert part1.gets('prevalence') == '0.19', part1.get('prevalence')
         assert len(part2.get('drugs')) == 0
-        return True
-
-    def give_feedback(self):
-        return None
 
 class TestFindTreatment3(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
 
-    def get_message(self):
+    def create_message(self):
         disease = ekb_kstring_from_text('common cold')
         content = KQMLList('FIND-TREATMENT')
         content.set('disease', disease)
         return get_request(content), content
 
-    def is_correct_response(self):
-        assert self.output.head() == 'FAILURE', self.output
-        assert self.output.gets('reason') == 'DISEASE_NOT_FOUND', self.output
-        return True
-
-    def give_feedback(self):
-        return None
+    def check_response_to_message(self, output):
+        assert output.head() == 'FAILURE', output
+        assert output.gets('reason') == 'DISEASE_NOT_FOUND', output
 

--- a/tests/general_test.py
+++ b/tests/general_test.py
@@ -29,17 +29,16 @@ class TestErrorHandling(_IntegrationTest):
 
         super(TestErrorHandling, self).__init__(TestAgent)
 
-    def get_message(self):
+    def create_message(self):
         content = KQMLList('TEST')
         content.sets('description', '')
         msg = KQMLPerformative('REQUEST')
         msg.set('content', content)
         return msg, content
 
-    def is_correct_response(self):
-        head = self.output.head()
+    def check_response_to_message(self, output):
+        head = output.head()
         assert head == "FAILURE",\
             "Got wrong output head: %s instead of FAILURE." % head
-        assert self.output.get('reason') == self.reason,\
+        assert output.get('reason') == self.reason,\
             "Exception caught too soon."
-        return True

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 from difflib import SequenceMatcher
 from kqml.kqml_performative import KQMLPerformative
 import logging
+from docutils.parsers.rst.states import InterpretedRoleNotImplementedError
 logging.basicConfig(format='%(levelname)s: %(name)s - %(message)s',
                     level=logging.INFO)
 logger = logging.getLogger('integration_tests')
@@ -44,7 +45,7 @@ def define_in_child(s):
     return "Define %s in the child!" % s
 
 
-class _IntegrationTest(TestCase):
+class _IntegrationTest_deprecated(TestCase):
     """An abstract class for creating integration tests of bioagents.
 
     Much of the functionality of bioagents comes with their ability to
@@ -98,26 +99,26 @@ class _IntegrationTest(TestCase):
         assert self.is_correct_response(), self.give_feedback()
 
 
-class _MultiRequestTest(_IntegrationTest):
+class _IntegrationTest(TestCase):
     """An abstract class for running a series of requests to the bioagent.
 
     As an example, such a test may be written as follows:
 
     ```
-    >> class TestFoo(_MultiRequestTest):
+    >> class TestFoo(_IntegrationTest):
     >>     message_funcs = ['prep', 'run']
     >>
-    >>     def send_prep(self):
+    >>     def create_prep(self):
     >>         "Creates the kqml message (msg) and content (content) for prep."
     >>         ...
     >>         return msg, content
     >>
-    >>     def send_run(self):
+    >>     def create_run(self):
     >>         "Creates the kqml message and content for runing something."
     >>         ...
     >>         return msg, content
     >>
-    >>     def check_run(self, output):
+    >>     def check_response_to_run(self, output):
     >>         "Checks that the output from the run is valid."
     >>         ...
     ```
@@ -131,6 +132,9 @@ class _MultiRequestTest(_IntegrationTest):
     `check_` methods must have one input, which will be the output content of
     `receive_request` call.
     
+    Single requests may also be made without any difficulty or altering of the
+    above paradigm. Note that message_funcs would not be needed in such cases.
+    
     Attributes:
     ----------
     message_funcs: (list) A list of the message names to be sent. This can be
@@ -138,12 +142,33 @@ class _MultiRequestTest(_IntegrationTest):
     
     Methods:
     -------
-    get_messages: creates a generator that iterates over the message methods 
+    _get_messages: creates a generator that iterates over the message methods 
         given by message_funcs, or else all methods with the `send_` prefix.
     run_test: runs the test.
+
+    Special Methods in Children:
+    ---------------------------
+    create_<message_func_name>: These functions must take no inputs, and return
+        a kqml msg and content to be input into the receive_request function of
+        a bioagent.
+    check_response_to_<message_func_name>: These functions contain asserts, and
+        any other similar means of checking the result of the corresponding call
+        to the bioagent, as per usual nosetest procedures. 
     """
     message_funcs = []
-    
+
+    def __init__(self, bioagent, **kwargs):
+        self.output = None  # BytesIO()
+        self.bioagent = bioagent(testing=True, **kwargs)  # out = self.output)
+        TestCase.__init__(self, 'run_test')
+
+    def __getattribute__(self, attr_name):
+        "Ensure that all attributes are implemented."
+        attr = TestCase.__getattribute__(self, attr_name)
+        if attr is NotImplemented:
+            raise NotImplementedError(define_in_child(attr_name))
+        return attr
+
     def _get_method_dict(self, prefix=''):
         """Get a dict of methods with the given prefix string."""
         return {
@@ -152,7 +177,7 @@ class _MultiRequestTest(_IntegrationTest):
             if callable(attr) and name.startswith(prefix)
             }
 
-    def get_messages(self):
+    def _get_messages(self):
         """Get a generator iterating over the methods to send messages.
         
         Yields:
@@ -161,8 +186,8 @@ class _MultiRequestTest(_IntegrationTest):
         check_func: (callable) a function used to check the result of a request,
             or else None, if no such check is to be made.
         """
-        send_dict = self._get_method_dict('send_')
-        check_dict = self._get_method_dict('check_')
+        send_dict = self._get_method_dict('create_')
+        check_dict = self._get_method_dict('check_response_to_')
         if not self.message_funcs:
             msg_list = send_dict.iterkeys()
         else:
@@ -172,7 +197,7 @@ class _MultiRequestTest(_IntegrationTest):
 
     def run_test(self):
         """Run the test."""
-        for request_args, check_resp in self.get_messages():
+        for request_args, check_resp in self._get_messages():
             _, output = self.bioagent.receive_request(*request_args)
             if check_resp is not None:
                 check_resp(output)
@@ -184,18 +209,17 @@ class _StringCompareTest(_IntegrationTest):
         super(_StringCompareTest, self).__init__(*args, **kwargs)
         self.expected = NotImplemented
 
-    def is_correct_response(self):
-        output_str = self.output.to_string()
-        return output_str == self.expected
+    def create_message(self):
+        raise NotImplementedError(define_in_child("the message constructor"))
 
-    def give_feedback(self):
-        """Return feedback comparing the expected to the result."""
-        ret_fmt = 'Did not get the expected output string:\n'
-        ret_fmt += 'Expected: %s\n' % self.expected
-        ret_fmt += 'Received: %s\n' % self.output.to_string()
-        ret_fmt += 'Diff: %s\n' % \
-            color_diff(self.expected, self.output.to_string())
-        return ret_fmt
+    def check_response_to_message(self, output):
+        output_str = output.to_string()
+        assert output_str == self.expected, (
+            'Did not get the expected output string:\n'
+            + 'Expected: %s\n' % self.expected
+            + 'Received: %s\n' % output.to_string()
+            + 'Diff: %s\n' % color_diff(self.expected, output.to_string())
+            )
 
 
 class _FailureTest(_IntegrationTest):
@@ -204,13 +228,9 @@ class _FailureTest(_IntegrationTest):
         super(_FailureTest, self).__init__(*args, **kwargs)
         self.expected_reason = NotImplemented
 
-    def is_correct_response(self):
-        assert self.output.head() == 'FAILURE', 'Head is not FAILURE'
-        reason = self.output.gets('reason')
+    def check_response_to_message(self, output):
+        assert output.head() == 'FAILURE', 'Head is not FAILURE'
+        reason = output.gets('reason')
         assert reason == self.expected_reason, \
             'Reason mismatch: %s instead of %s' % \
             (reason, self.expected_reason)
-        return True
-
-    def give_feedback(self):
-        pass

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -157,6 +157,7 @@ class _IntegrationTest(TestCase):
     def __init__(self, bioagent, **kwargs):
         self.output = None  # BytesIO()
         self.bioagent = bioagent(testing=True, **kwargs)  # out = self.output)
+        
         TestCase.__init__(self, 'run_test')
 
     def __getattribute__(self, attr_name):
@@ -166,6 +167,7 @@ class _IntegrationTest(TestCase):
             raise NotImplementedError(define_in_child(attr_name))
         return attr
 
+    @classmethod
     def _get_method_dict(self, prefix=''):
         """Get a dict of methods with the given prefix string."""
         return {
@@ -186,18 +188,17 @@ class _IntegrationTest(TestCase):
         send_dict = self._get_method_dict('create_')
         check_dict = self._get_method_dict('check_response_to_')
         if not self.message_funcs:
-            msg_list = send_dict.iterkeys()
+            msg_list = send_dict.keys()
         else:
             msg_list = self.message_funcs[:]
         for msg in msg_list:
-            yield send_dict[msg](), check_dict.get(msg)
+            yield send_dict[msg](self), check_dict.get(msg)
 
     def run_test(self):
-        """Run the test."""
         for request_args, check_resp in self._get_messages():
             _, output = self.bioagent.receive_request(*request_args)
             if check_resp is not None:
-                check_resp(output)
+                check_resp(self, output)
 
 
 class _StringCompareTest(_IntegrationTest):

--- a/tests/integration.py
+++ b/tests/integration.py
@@ -1,9 +1,6 @@
-from io import BytesIO
 from unittest import TestCase
 from difflib import SequenceMatcher
-from kqml.kqml_performative import KQMLPerformative
 import logging
-from docutils.parsers.rst.states import InterpretedRoleNotImplementedError
 logging.basicConfig(format='%(levelname)s: %(name)s - %(message)s',
                     level=logging.INFO)
 logger = logging.getLogger('integration_tests')

--- a/tests/tra_test.py
+++ b/tests/tra_test.py
@@ -330,7 +330,7 @@ class _TraTestModel1(_StringCompareTest):
             ':num-sim 10 :suggestion (:type "always_value" ' + \
             ':value (:type "qualitative" :value "low"))))'
 
-    def get_message(self):
+    def create_message(self):
         model = stmts_kstring_from_text('MAP2K1 binds MAPK1')
         entity = ekb_kstring_from_text('MAPK1-MAP2K1 complex')
         condition_entity = ekb_kstring_from_text('MAP2K1')
@@ -387,7 +387,7 @@ class TraTestModel2(_StringCompareTest):
             ':num-sim 10 :suggestion (:type "always_value" ' + \
             ':value (:type "qualitative" :value "high"))))'
 
-    def get_message(self):
+    def create_message(self):
         model = stmts_kstring_from_text('MEK binds ERK')
         entity = ekb_kstring_from_text('MEK bound to ERK')
 
@@ -420,7 +420,7 @@ class TraTestModel3(_StringCompareTest):
             ':num-sim 10 :suggestion (:type "eventual_value" ' + \
             ':value (:type "qualitative" :value "high"))))'
 
-    def get_message(self):
+    def create_message(self):
         model = stmts_kstring_from_text('MEK phosphorylates ERK')
         entity = ekb_kstring_from_text('ERK that is phosphorylated')
 


### PR DESCRIPTION
This PR by @pagreene adds support for Bioagents integration tests with multiple rounds of requests and responses. This is useful for Bioagents which maintain state like the MRA.