### PR TITLE
Sbgnviz prov msa

### DIFF
--- a/bioagents/__init__.py
+++ b/bioagents/__init__.py
@@ -77,6 +77,12 @@ class Bioagent(KQMLModule):
             self.reply(msg, reply_msg)
         return (msg, reply_content)
 
+    def tell(self, content):
+        """Send a tell message."""
+        msg = KQMLPerformative('tell')
+        msg.set('content', content)
+        return self.send(msg)
+
     def error_reply(self, msg, comment):
         if not self.testing:
             return KQMLModule.error_reply(self, msg, comment)

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -90,7 +90,7 @@ class MSA_Module(Bioagent):
         stmt_evidence_fmt = ('Found at pmid <a href={url}={pmid} '
                              'target="_blank">{pmid}</a>:\n<ul>{evidence}\n'
                              '</ul>')
-        content_fmt = '<text>Supporting evidence for "%s":\n%s</text><hr>'
+        content_fmt = '<text>Supporting evidence for \'%s\':\n%s</text><hr>'
 
         # Extract a list of the evidence then map pmids to lists of text
         evidence_list = [stmt.evidence[0] for stmt in related_results]
@@ -104,7 +104,7 @@ class MSA_Module(Bioagent):
             stmt_evidence_fmt.format(
                 url=url_base,
                 pmid=pmid,
-                evidence='\n'.join(['<li><i>"%s"</i></li>' % e for e in elist])
+                evidence='\n'.join(['<li><i>\'%s\'</i></li>' % e for e in elist])
                 )
             for pmid, elist in pmid_text_dict.items()
             ])

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -64,7 +64,7 @@ class MSA_Module(Bioagent):
         else:
             tell_msg = KQMLPerformative('tell')
             content = KQMLList('add-provenance')
-            content.sets('html', 'THIS IS PROVENANCE')
+            content.sets('html', '<text>THIS IS PROVENANCE</text>')
             tell_msg.set('content', content)
             self.send(tell_msg)
             msg = KQMLPerformative('SUCCESS')

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -80,7 +80,7 @@ class MSA_Module(Bioagent):
         """
         url_base = 'https://www.ncbi.nlm.nih.gov/pubmed/?term'
         stmt_evidence_fmt = \
-            "'<i>{text}</i>' found at pmid <a href={url}={pmid}>{pmid}</a>."
+            '"<i>{text}</i>" found at pmid <a href={url}={pmid} target="_blank">{pmid}</a>.'
         content_fmt = "<text>Supporting evidence:\n%s</text><hr>"
         content = KQMLList('add-provenance')
         evidence_list = [stmt.evidence[0] for stmt in related_results]

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -62,14 +62,38 @@ class MSA_Module(Bioagent):
                 "%s, %s, %s, %s." % (agent.name, residue, position, 'phosphorylation')
                 )
         else:
-            tell_msg = KQMLPerformative('tell')
-            content = KQMLList('add-provenance')
-            content.sets('html', '<text>THIS IS PROVENANCE</text>')
-            tell_msg.set('content', content)
-            self.send(tell_msg)
+            self._add_provenance(related_results)
             msg = KQMLPerformative('SUCCESS')
             msg.set('is-activating', 'TRUE')
             return msg
+
+    def tell(self, content):
+        """Send a tell message."""
+        msg = KQMLPerformative('tell')
+        msg.set('content', content)
+        return self.send(msg)
+
+    def _add_provenance(self, related_results):
+        """Creates the content for an add-provenance tell message.
+
+        The message is used to provide evidence supporting the conclusion.
+        """
+        content_fmt = ("<text>Supporting evidence: \"%s\" found in "
+                       "<a href=%s>. %d other statements were also found to "
+                       "support this conclusion.</text>")
+        content = KQMLList('add-provenance')
+        stmt = related_results.pop()
+        evidence = stmt.evidence[0]
+        url = 'https://www.ncbi.nlm.nih.gov/pubmed/?term=' + evidence.pmid
+        content.sets(
+            'html',
+            content_fmt % (
+                evidence.text,
+                url,
+                len(related_results)
+                )
+            )
+        return self.tell(content)
 
     @staticmethod
     def _get_agent(agent_ekb):

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -4,7 +4,7 @@ import logging
 import re
 from bioagents import Bioagent
 from indra.sources.trips.processor import TripsProcessor
-from kqml import KQMLPerformative
+from kqml import KQMLPerformative, KQMLList
 import pickle
 
 
@@ -63,7 +63,7 @@ class MSA_Module(Bioagent):
                 )
         else:
             tell_msg = KQMLPerformative('tell')
-            content = KQMLPerformative('add-provenance')
+            content = KQMLList('add-provenance')
             content.sets('html', 'THIS IS PROVENANCE')
             tell_msg.set('content', content)
             self.send(tell_msg)

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -64,10 +64,7 @@ class MSA_Module(Bioagent):
         else:
             tell_msg = KQMLPerformative('tell')
             content = KQMLPerformative('add-provenance')
-            content.sets('html', '\n'.join([
-                '%s' % str(s)
-                for s in related_results
-                ]))
+            content.sets('html', 'THIS IS PROVENANCE')
             tell_msg.set('content', content)
             self.send(tell_msg)
             msg = KQMLPerformative('SUCCESS')

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -79,20 +79,24 @@ class MSA_Module(Bioagent):
         The message is used to provide evidence supporting the conclusion.
         """
         url_base = 'https://www.ncbi.nlm.nih.gov/pubmed/?term'
-        stmt_evidence_fmt = \
-            '"<i>{text}</i>" found at pmid <a href={url}={pmid} target="_blank">{pmid}</a>.'
+        stmt_evidence_fmt = ('Found at pmid <a href={url}={pmid} '
+                             'target="_blank">{pmid}</a>:\n\n{evidence}')
         content_fmt = "<text>Supporting evidence:\n%s</text><hr>"
         content = KQMLList('add-provenance')
         evidence_list = [stmt.evidence[0] for stmt in related_results]
+        pmid_text_dict = {
+            pmid: [e.text for e in evidence_list if e.pmid == pmid]
+            for pmid in set([e.pmid for e in evidence_list])
+            }
         content.sets(
             'html',
             content_fmt % '\n'.join([
                 stmt_evidence_fmt.format(
-                    text=evidence.text,
                     url=url_base,
-                    pmid=evidence.pmid
+                    pmid=pmid,
+                    evidence='\n\n'.join(['<i>%s</i>' % e for e in elist])
                     )
-                for evidence in evidence_list
+                for pmid, elist in pmid_text_dict.items()
                 ])
             )
         return self.tell(content)

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -78,9 +78,9 @@ class MSA_Module(Bioagent):
 
         The message is used to provide evidence supporting the conclusion.
         """
-        content_fmt = ("<text>Supporting evidence: \"%s\" found in "
-                       "<a href=%s>. %d other statements were also found to "
-                       "support this conclusion.</text>")
+        content_fmt = ("<text>Supporting evidence: '%s' found  "
+                       "<a href=%s>here</a>. I also found %d other statements "
+                       "to support this conclusion.</text>")
         content = KQMLList('add-provenance')
         stmt = related_results.pop()
         evidence = stmt.evidence[0]

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -80,7 +80,7 @@ class MSA_Module(Bioagent):
         """
         url_base = 'https://www.ncbi.nlm.nih.gov/pubmed/?term'
         stmt_evidence_fmt = \
-            "'{text}' found at pmid <a {url}={pmid}>{pmid}</a>."
+            "'<i>{text}</i>' found at pmid <a href={url}={pmid}>{pmid}</a>."
         content_fmt = "<text>Supporting evidence:\n%s</text><hr>"
         content = KQMLList('add-provenance')
         evidence_list = [stmt.evidence[0] for stmt in related_results]

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -74,12 +74,6 @@ class MSA_Module(Bioagent):
             msg.set('is-activating', 'TRUE')
             return msg
 
-    def tell(self, content):
-        """Send a tell message."""
-        msg = KQMLPerformative('tell')
-        msg.set('content', content)
-        return self.send(msg)
-
     def _add_provenance(self, related_results, for_what):
         """Creates the content for an add-provenance tell message.
 

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -61,9 +61,18 @@ class MSA_Module(Bioagent):
                 "Could not find statement matching phosphorylation activating "
                 "%s, %s, %s, %s." % (agent.name, residue, position, 'phosphorylation')
                 )
-        msg = KQMLPerformative('SUCCESS')
-        msg.set('is-activating', 'TRUE')
-        return msg
+        else:
+            tell_msg = KQMLPerformative('tell')
+            content = KQMLPerformative('add-provenance')
+            content.sets('html', '\n'.join([
+                '%s' % str(s)
+                for s in related_results
+                ]))
+            tell_msg.set('content', content)
+            self.send(tell_msg)
+            msg = KQMLPerformative('SUCCESS')
+            msg.set('is-activating', 'TRUE')
+            return msg
 
     @staticmethod
     def _get_agent(agent_ekb):

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -89,8 +89,8 @@ class MSA_Module(Bioagent):
         url_base = 'https://www.ncbi.nlm.nih.gov/pubmed/?term'
         stmt_evidence_fmt = ('Found at pmid <a href={url}={pmid} '
                              'target="_blank">{pmid}</a>:\n<ul>{evidence}\n'
-                             '</ul>\n')
-        content_fmt = "<text>Supporting evidence for %s:\n%s</text><hr>"
+                             '</ul>')
+        content_fmt = '<text>Supporting evidence for "%s":\n%s</text><hr>'
 
         # Extract a list of the evidence then map pmids to lists of text
         evidence_list = [stmt.evidence[0] for stmt in related_results]
@@ -104,7 +104,7 @@ class MSA_Module(Bioagent):
             stmt_evidence_fmt.format(
                 url=url_base,
                 pmid=pmid,
-                evidence='\n'.join(['<li><i>%s</i></li>' % e for e in elist])
+                evidence='\n'.join(['<li><i>"%s"</i></li>' % e for e in elist])
                 )
             for pmid, elist in pmid_text_dict.items()
             ])

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -78,20 +78,22 @@ class MSA_Module(Bioagent):
 
         The message is used to provide evidence supporting the conclusion.
         """
-        content_fmt = ("<text>Supporting evidence: '%s' found  "
-                       "<a href=%s>here</a>. I also found %d other statements "
-                       "to support this conclusion.</text>")
+        url_base = 'https://www.ncbi.nlm.nih.gov/pubmed/?term'
+        stmt_evidence_fmt = \
+            "'{text}' found at pmid <a {url}={pmid}>{pmid}</a>."
+        content_fmt = "<text>Supporting evidence:\n%s</text><hr>"
         content = KQMLList('add-provenance')
-        stmt = related_results.pop()
-        evidence = stmt.evidence[0]
-        url = 'https://www.ncbi.nlm.nih.gov/pubmed/?term=' + evidence.pmid
+        evidence_list = [stmt.evidence[0] for stmt in related_results]
         content.sets(
             'html',
-            content_fmt % (
-                evidence.text,
-                url,
-                len(related_results)
-                )
+            content_fmt % '\n'.join([
+                stmt_evidence_fmt.format(
+                    text=evidence.text,
+                    url=url_base,
+                    pmid=evidence.pmid
+                    )
+                for evidence in evidence_list
+                ])
             )
         return self.tell(content)
 

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -80,7 +80,7 @@ class MSA_Module(Bioagent):
         """
         url_base = 'https://www.ncbi.nlm.nih.gov/pubmed/?term'
         stmt_evidence_fmt = ('Found at pmid <a href={url}={pmid} '
-                             'target="_blank">{pmid}</a>:\n\n{evidence}')
+                             'target="_blank">{pmid}</a>:\n{evidence}\n\n')
         content_fmt = "<text>Supporting evidence:\n%s</text><hr>"
         content = KQMLList('add-provenance')
         evidence_list = [stmt.evidence[0] for stmt in related_results]
@@ -94,7 +94,7 @@ class MSA_Module(Bioagent):
                 stmt_evidence_fmt.format(
                     url=url_base,
                     pmid=pmid,
-                    evidence='\n\n'.join(['<i>%s</i>' % e for e in elist])
+                    evidence='\n'.join(['<i>%s</i>' % e for e in elist])
                     )
                 for pmid, elist in pmid_text_dict.items()
                 ])

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -85,24 +85,32 @@ class MSA_Module(Bioagent):
 
         The message is used to provide evidence supporting the conclusion.
         """
+        # Create some formats
         url_base = 'https://www.ncbi.nlm.nih.gov/pubmed/?term'
         stmt_evidence_fmt = ('Found at pmid <a href={url}={pmid} '
-                             'target="_blank">{pmid}</a>:\n{evidence}\n\n')
+                             'target="_blank">{pmid}</a>:\n<ul>{evidence}\n'
+                             '</ul>\n')
         content_fmt = "<text>Supporting evidence for %s:\n%s</text><hr>"
-        content = KQMLList('add-provenance')
+
+        # Extract a list of the evidence then map pmids to lists of text
         evidence_list = [stmt.evidence[0] for stmt in related_results]
         pmid_text_dict = {
             pmid: [e.text for e in evidence_list if e.pmid == pmid]
             for pmid in set([e.pmid for e in evidence_list])
             }
+
+        # Create the text for displaying the evidence.
         evidence_text = '\n'.join([
             stmt_evidence_fmt.format(
                 url=url_base,
                 pmid=pmid,
-                evidence='\n'.join(['<i>%s</i>' % e for e in elist])
+                evidence='\n'.join(['<li><i>%s</i></li>' % e for e in elist])
                 )
             for pmid, elist in pmid_text_dict.items()
             ])
+
+        # Actually create the content.
+        content = KQMLList('add-provenance')
         content.sets(
             'html',
             content_fmt % (for_what, evidence_text)


### PR DESCRIPTION
Create a provenance tab for the sbgnviz application to go with responses from the MSA. The evidence for the response is now printed in provenance.