### PR TITLE
Biosense get synonyms

### DIFF
--- a/bioagents/biosense/biosense_module.py
+++ b/bioagents/biosense/biosense_module.py
@@ -5,8 +5,9 @@ import indra
 from indra.util import read_unicode_csv
 from indra.tools import expand_families
 from indra.sources import trips
+from indra.sources.trips.processor import TripsProcessor
 from bioagents import Bioagent
-from indra.databases import get_identifiers_url
+from indra.databases import get_identifiers_url, uniprot_client
 from indra.preassembler.hierarchy_manager import hierarchies
 from kqml import KQMLModule, KQMLPerformative, KQMLList, KQMLString
 
@@ -126,22 +127,32 @@ class BioSense_Module(Bioagent):
         return msg
 
     def respond_get_synonyms(self, content):
-        """Respond to a query looking for synonyms of a gene."""
-        ekb = content.gets('gene')
-        agents, _ = process_ekb(ekb)
-        if len(agents) != 1:
-            return self.make_failure('INVALID_COLLECTION')
+        """Respond to a query looking for synonyms of a protein."""
+        ekb = content.gets('protein')
+        try:
+            agent = self._get_agent(ekb)
+        except Exception as e:
+            return self.make_failure('INVALID_AGENT')
+        if agent is None:
+            return self.make_failure('INVALID_AGENT')
 
-        agent = agents[0]
-        up_id = agent.db_refs['UP']
-        gene_name = up_client.get_gene_name(up_id)
-        gene_synonyms = up_client.get_gene_alt_labels(up_id)
-        protein_names = up_client.get_gene_alt_names(up_id)
+        up_id = agent.db_refs.get('UP')
+        if not up_id:
+            return self.make_failure('INVALID_AGENT')
+
+        synonyms = uniprot_client.get_synonyms(up_id)
+        syns = KQMLList([KQMLString(s) for s in synonyms])
         msg = KQMLList('SUCCESS')
-        msg.set('gene_name', gene_name)
-        msg.set('gene_synonyms', gene_synonyms)
-        msg.set('protein_names', protein_names)
+        msg.set('synonyms', syns)
         return msg
+
+    @staticmethod
+    def _get_agent(agent_ekb):
+        tp = TripsProcessor(agent_ekb)
+        terms = tp.tree.findall('TERM')
+        term_id = terms[0].attrib['id']
+        agent = tp._get_agent_by_id(term_id, None)
+        return agent
 
 
 def get_kagent(agent_tuple, term_id=None):

--- a/bioagents/biosense/biosense_module.py
+++ b/bioagents/biosense/biosense_module.py
@@ -23,7 +23,8 @@ _indra_path = indra.__path__[0]
 class BioSense_Module(Bioagent):
     name = 'BioSense'
     tasks = ['CHOOSE-SENSE', 'CHOOSE-SENSE-CATEGORY',
-             'CHOOSE-SENSE-IS-MEMBER', 'CHOOSE-SENSE-WHAT-MEMBER']
+             'CHOOSE-SENSE-IS-MEMBER', 'CHOOSE-SENSE-WHAT-MEMBER',
+             'GET-SYNONYMS']
 
     def respond_choose_sense(self, content):
         """Return response content to choose-sense request."""

--- a/bioagents/biosense/biosense_module.py
+++ b/bioagents/biosense/biosense_module.py
@@ -125,6 +125,24 @@ class BioSense_Module(Bioagent):
         msg.set('members', KQMLList(kagents))
         return msg
 
+    def respond_get_synonyms(self, content):
+        """Respond to a query looking for synonyms of a gene."""
+        ekb = content.gets('gene')
+        agents, _ = process_ekb(ekb)
+        if len(agents) != 1:
+            return self.make_failure('INVALID_COLLECTION')
+
+        agent = agents[0]
+        up_id = agent.db_refs['UP']
+        gene_name = up_client.get_gene_name(up_id)
+        gene_synonyms = up_client.get_gene_alt_labels(up_id)
+        protein_names = up_client.get_gene_alt_names(up_id)
+        msg = KQMLList('SUCCESS')
+        msg.set('gene_name', gene_name)
+        msg.set('gene_synonyms', gene_synonyms)
+        msg.set('protein_names', protein_names)
+        return msg
+
 
 def get_kagent(agent_tuple, term_id=None):
     agent, ont_type, urls = agent_tuple

--- a/bioagents/tests/biosense_test.py
+++ b/bioagents/tests/biosense_test.py
@@ -1,6 +1,6 @@
 import unittest
 from kqml import KQMLList
-from .util import ekb_from_text
+from bioagents.tests.util import ekb_from_text
 from bioagents.biosense.biosense_module import BioSense_Module
 
 mek1_ekb = ekb_from_text('MAP2K1')
@@ -103,3 +103,17 @@ def test_choose_sense_what_member():
     m2 = res.get('members')[1]
     assert m1.gets('name') == 'MAP2K1', m1.gets('name')
     assert m2.gets('name') == 'MAP2K2', m2.gets('name')
+
+
+def test_get_synonym():
+    bs = BioSense_Module(testing=True)
+    msg_content = KQMLList('GET-SYNONYMS')
+    msg_content.sets('protein', mek1_ekb)
+    res = bs.respond_get_synonyms(msg_content)
+    assert res.head() == 'SUCCESS'
+    syns = res.get('synonyms')
+    syn_strs = [s.string_value() for s in syns]
+    assert 'MAP2K1' in syn_strs
+    assert 'MEK1' in syn_strs
+    assert 'MKK1' in syn_strs
+


### PR DESCRIPTION
This PR adds BioSense endpoint for getting the synonyms of a protein (it works only if the entity has a UniProt ID).