### PR TITLE
Speed up the MSA response and improve ordering and references

### DIFF
--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -279,8 +279,9 @@ class MSA_Module(Bioagent):
 
     def _format_evidence(self, ev_list):
         """Format the evidence of a statement for display."""
-        fmt = '<a href=https://www.ncbi.nlm.nih.gov/pubmed/{pmid}>{pmid}</a>'
-        pmids = [fmt.format(pmid=ev.pmid) if ev.pmid else 'None'
+        fmt = ('{source_api}: <a href=https://www.ncbi.nlm.nih.gov/pubmed/'
+               '{pmid}>{pmid}</a>')
+        pmids = [fmt.format(**ev.__dict__) if ev.pmid else 'None'
                  for ev in ev_list[:10]]
         return ','.join(pmids)
 

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -275,11 +275,13 @@ class MSA_Module(Bioagent):
         # content.sets('graph', resource)
         # self.tell(content)
 
-    def _format_evidence(self, ev_list):
+    def _format_evidence(self, ev_list, ev_count):
         """Format the evidence of a statement for display."""
         fmt = ('{source_api}: <a href=https://www.ncbi.nlm.nih.gov/pubmed/'
                '{pmid} target="_blank">{pmid}</a>')
         pmids = [fmt.format(**ev.__dict__) for ev in ev_list[:10]]
+        if len(pmids) < ev_count:
+            pmids.append('...and %d more!' % (ev_count - len(pmids)))
         return ', '.join(pmids)
 
     def _send_table_to_provenance(self, resp, nl_question):
@@ -290,9 +292,10 @@ class MSA_Module(Bioagent):
                     '<th>Source and PMID</th>']
         for stmt in resp.statements[:DUMP_LIMIT]:
             sub_ag, obj_ag = stmt.agent_list()
+            ev_str = self._format_evidence(stmt.evidence,
+                                           resp.get_ev_count(stmt))
             row_list.append('<td>%s</td><td>%s</td><td>%s</td><td>%s</td>'
-                            % (sub_ag, type(stmt).__name__, obj_ag,
-                               self._format_evidence(stmt.evidence)))
+                            % (sub_ag, type(stmt).__name__, obj_ag, ev_str))
         html_str += '\n'.join(['  <tr>%s</tr>\n' % row_str
                                for row_str in row_list])
         html_str += '</table>'

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -266,16 +266,7 @@ class MSA_Module(Bioagent):
     def _send_display_stmts(self, stmts, nl_question):
         start_time = datetime.now()
         logger.info('Sending display statements.')
-        display_stmts = []
-        for stmt_type, stmt_grp in groupby(stmts, key=lambda s: str(type(s))):
-            stmt_sublist = list(stmt_grp)
-            logger.info("There are %d statements of type %s."
-                        % (len(stmt_sublist), stmt_type))
-            stmt_sublist.sort(key=lambda s: len(s.evidence)+len(s.supported_by))
-            display_stmts.extend(stmt_sublist[:DUMP_LIMIT])
-        logger.info("Finished processing statements after %s seconds."
-                    % (datetime.now() - start_time).total_seconds())
-        self._send_table_to_provenance(display_stmts, nl_question)
+        self._send_table_to_provenance(stmts, nl_question)
         logger.info("Finished sending provenance after %s seconds."
                     % (datetime.now() - start_time).total_seconds())
 

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -281,11 +281,13 @@ class MSA_Module(Bioagent):
         """Post a concise table listing statements found."""
         html_str = '<h4>Statements matching: %s</h4>\n' % nl_question
         html_str += '<table style="width:100%">\n'
-        row_list = ['<th>Source</th><th>Interactions</th><th>Target</th>']
+        row_list = ['<th>Source</th><th>Interactions</th><th>Target</th>'
+                    '<th>PMID</th>']
         for stmt in stmts[:DUMP_LIMIT]:
             sub_ag, obj_ag = stmt.agent_list()
-            row_list.append('<td>%s</td><td>%s</td><td>%s</td>'
-                            % (sub_ag, type(stmt).__name__, obj_ag))
+            row_list.append('<td>%s</td><td>%s</td><td>%s</td><td>%s</td>'
+                            % (sub_ag, type(stmt).__name__, obj_ag,
+                               ','.join(ev.pmid for ev in stmt.evidence[:10])))
         html_str += '\n'.join(['  <tr>%s</tr>\n' % row_str
                                for row_str in row_list])
         html_str += '</table>'

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -278,16 +278,15 @@ class MSA_Module(Bioagent):
         """Format the evidence of a statement for display."""
         fmt = ('{source_api}: <a href=https://www.ncbi.nlm.nih.gov/pubmed/'
                '{pmid} target="_blank">{pmid}</a>')
-        pmids = [fmt.format(**ev.__dict__) if ev.pmid else 'None'
-                 for ev in ev_list[:10]]
-        return ','.join(pmids)
+        pmids = [fmt.format(**ev.__dict__) for ev in ev_list[:10]]
+        return ', '.join(pmids)
 
     def _send_table_to_provenance(self, stmts, nl_question):
         """Post a concise table listing statements found."""
         html_str = '<h4>Statements matching: %s</h4>\n' % nl_question
         html_str += '<table style="width:100%">\n'
         row_list = ['<th>Source</th><th>Interactions</th><th>Target</th>'
-                    '<th>PMID</th>']
+                    '<th>Source and PMID</th>']
         for stmt in stmts[:DUMP_LIMIT]:
             sub_ag, obj_ag = stmt.agent_list()
             row_list.append('<td>%s</td><td>%s</td><td>%s</td><td>%s</td>'

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -3,6 +3,7 @@ import sys
 import re
 import pickle
 import logging
+from datetime import datetime
 from itertools import groupby
 
 logging.basicConfig(format='%(levelname)s: %(name)s - %(message)s',
@@ -123,6 +124,7 @@ class MSA_Module(Bioagent):
 
     def _lookup_from_source_type_target(self, content, desc):
         """Look up statement given format received by find/confirm relations."""
+        start_time = datetime.now()
         agent_dict = dict.fromkeys(['subject', 'object'])
         for pos, loc in [('subject', 'source'), ('object', 'target')]:
             ekb = content.gets(loc)
@@ -173,6 +175,9 @@ class MSA_Module(Bioagent):
 
         # Sort statements by support and evidence
         stmts.sort(key=lambda s: len(s.evidence) + len(s.supported_by))
+
+        logger.info("Retrieved statements after %s seconds."
+                    % (datetime.now() - start_time).total_seconds())
 
         return nl, stmts
 
@@ -259,7 +264,8 @@ class MSA_Module(Bioagent):
             self.tell(content)
 
     def _send_display_stmts(self, stmts, nl_question):
-        logger.info('Sending display statements')
+        start_time = datetime.now()
+        logger.info('Sending display statements.')
         display_stmts = []
         for stmt_type, stmt_grp in groupby(stmts, key=lambda s: str(type(s))):
             stmt_sublist = list(stmt_grp)
@@ -267,7 +273,12 @@ class MSA_Module(Bioagent):
                         % (len(stmt_sublist), stmt_type))
             stmt_sublist.sort(key=lambda s: len(s.evidence)+len(s.supported_by))
             display_stmts.extend(stmt_sublist[:DUMP_LIMIT])
+        logger.info("Finished processing statements after %s seconds."
+                    % (datetime.now() - start_time).total_seconds())
         self._send_table_to_provenance(display_stmts, nl_question)
+        logger.info("Finished sending provenance after %s seconds."
+                    % (datetime.now() - start_time).total_seconds())
+
         # resource = _make_sbgn(stmts[:10])
         # logger.info(resource)
         # content = KQMLList('open-query-window')

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -277,6 +277,13 @@ class MSA_Module(Bioagent):
         # content.sets('graph', resource)
         # self.tell(content)
 
+    def _format_evidence(self, ev_list):
+        """Format the evidence of a statement for display."""
+        fmt = '<a href=https://www.ncbi.nlm.nih.gov/pubmed/{pmid}>{pmid}</a>'
+        pmids = [fmt.format(pmid=ev.pmid) if ev.pmid else 'None'
+                 for ev in ev_list[:10]]
+        return ','.join(pmids)
+
     def _send_table_to_provenance(self, stmts, nl_question):
         """Post a concise table listing statements found."""
         html_str = '<h4>Statements matching: %s</h4>\n' % nl_question
@@ -287,7 +294,7 @@ class MSA_Module(Bioagent):
             sub_ag, obj_ag = stmt.agent_list()
             row_list.append('<td>%s</td><td>%s</td><td>%s</td><td>%s</td>'
                             % (sub_ag, type(stmt).__name__, obj_ag,
-                               ','.join(ev.pmid for ev in stmt.evidence[:10])))
+                               self._format_evidence(stmt.evidence)))
         html_str += '\n'.join(['  <tr>%s</tr>\n' % row_str
                                for row_str in row_list])
         html_str += '</table>'

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -276,8 +276,8 @@ class MSA_Module(Bioagent):
 
     def _format_evidence(self, ev_list):
         """Format the evidence of a statement for display."""
-        fmt = ('{source_api}: <a href="https://www.ncbi.nlm.nih.gov/pubmed/'
-               '{pmid}" target="_blank">{pmid}</a>')
+        fmt = ('{source_api}: <a href=https://www.ncbi.nlm.nih.gov/pubmed/'
+               '{pmid} target="_blank">{pmid}</a>')
         pmids = [fmt.format(**ev.__dict__) if ev.pmid else 'None'
                  for ev in ev_list[:10]]
         return ','.join(pmids)

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -173,9 +173,6 @@ class MSA_Module(Bioagent):
             logger.exception(e)
             raise MSALookupError('MISSING_MECHANISM')
 
-        # Sort statements by support and evidence
-        stmts.sort(key=lambda s: len(s.evidence) + len(s.supported_by))
-
         logger.info("Retrieved statements after %s seconds."
                     % (datetime.now() - start_time).total_seconds())
 
@@ -279,8 +276,8 @@ class MSA_Module(Bioagent):
 
     def _format_evidence(self, ev_list):
         """Format the evidence of a statement for display."""
-        fmt = ('{source_api}: <a href=https://www.ncbi.nlm.nih.gov/pubmed/'
-               '{pmid}>{pmid}</a>')
+        fmt = ('{source_api}: <a href="https://www.ncbi.nlm.nih.gov/pubmed/'
+               '{pmid}" target="_blank">{pmid}</a>')
         pmids = [fmt.format(**ev.__dict__) if ev.pmid else 'None'
                  for ev in ev_list[:10]]
         return ','.join(pmids)


### PR DESCRIPTION
This change leverages updates to INDRA and the INDRA DB to:
- Vastly speed up MSA responses
- Provide pmids, with links out
- indicate the total amount of evidence for each table entry.