### PR TITLE
Background Provenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,14 @@ script:
   - export PYTHONPATH=$PYTHONPATH:$TRAVIS_BUILD_DIR
   # Run standard unit tests
   - cd $TRAVIS_BUILD_DIR
-  - nosetests bioagents/tests -v --with-coverage --cover-inclusive --cover-package=bioagents
+  - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
+        export RUN_SLOW=true;
+    fi
+  - export NOSEATTR="";
+  - if [[ $TRAVIS_PULL_REQUEST ]]; then
+      export NOSEATTR="!nonpublic,!webservice";
+    fi
+  - if [[ $RUN_SLOW != "true" ]]; then
+      export NOSEATTR="!slow,$NOSEATTR";
+    fi
+  - nosetests bioagents/tests -a $NOSEATTR -v --with-coverage --cover-inclusive --cover-package=bioagents

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ script:
     fi
   - export NOSEATTR="";
   - if [[ $TRAVIS_PULL_REQUEST ]]; then
-      export NOSEATTR="!nonpublic,!webservice";
+      export NOSEATTR="!nonpublic";
     fi
   - if [[ $RUN_SLOW != "true" ]]; then
       export NOSEATTR="!slow,$NOSEATTR";

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - pip install git+https://github.com/sorgerlab/indra.git
   # Dependencies of Bioagents not covered by previous installs
   - sudo apt-get install graphviz
-  - pip install pygraphviz ndex2
+  - pip install pygraphviz ndex2==1.2.0.58
   - pip install -U networkx>=2
   - wget -nv "http://sorger.med.harvard.edu/data/bgyori/bioagents/drug_targets.db" -O bioagents/resources/drug_targets.db
   # Install utilities for running tests

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -213,7 +213,7 @@ class MSA_Module(Bioagent):
         if not res_dict['done']:
             # Calling this success may be a bit ambitious.
             resp = KQMLPerformative('SUCCESS')
-            resp.set('finished', 't')
+            resp.set('finished', 'nil')
             resp.set('relations-found', 'nil')
             resp.set('dump-limit', str(DUMP_LIMIT))
             return resp

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -177,7 +177,7 @@ class MSA_Module(Bioagent):
 
         num_stmts = len(resp.statements)
         logger.info("Retrieved %d statements after %s seconds."
-                    % (num_stmts, datetime.now() - start_time).total_seconds())
+                    % (num_stmts, (datetime.now()-start_time).total_seconds()))
         if num_stmts and send_provenance:
             try:
                 self._send_display_stmts(resp, nl)
@@ -213,8 +213,8 @@ class MSA_Module(Bioagent):
         if not res_dict['done']:
             # Calling this success may be a bit ambitious.
             resp = KQMLPerformative('SUCCESS')
-            resp.set('finished', False)
-            resp.set('relations-found', None)
+            resp.set('finished', 't')
+            resp.set('relations-found', 'nil')
             resp.set('dump-limit', str(DUMP_LIMIT))
             return resp
 
@@ -223,7 +223,7 @@ class MSA_Module(Bioagent):
 
         rest_resp = res_dict['result']
         resp = KQMLPerformative('SUCCESS')
-        resp.set('finished', True)
+        resp.set('finished', 't')
         resp.set('relations-found', str(len(rest_resp.statements)))
         resp.set('dump-limit', str(DUMP_LIMIT))
         return resp

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -210,22 +210,23 @@ class MSA_Module(Bioagent):
     def respond_find_relations_from_literature(self, content):
         """Find statements matching some subject, verb, object information."""
         res_dict = self._run_lookup_in_thread(content, 'Find')
-        if res_dict['done']:
-            if res_dict['failed']:
-                return self.make_failure(res_dict['result'])
-            else:
-                rest_resp = res_dict['result']
-                resp = KQMLPerformative('SUCCESS')
-                resp.set('finished', True)
-                resp.set('relations-found', str(len(rest_resp.statements)))
-                resp.set('dump-limit', str(DUMP_LIMIT))
-                return resp
-        else:
+        if not res_dict['done']:
+            # Calling this success may be a bit ambitious.
             resp = KQMLPerformative('SUCCESS')
             resp.set('finished', False)
             resp.set('relations-found', None)
             resp.set('dump-limit', str(DUMP_LIMIT))
             return resp
+
+        if res_dict['failed']:
+            return self.make_failure(res_dict['result'])
+
+        rest_resp = res_dict['result']
+        resp = KQMLPerformative('SUCCESS')
+        resp.set('finished', True)
+        resp.set('relations-found', str(len(rest_resp.statements)))
+        resp.set('dump-limit', str(DUMP_LIMIT))
+        return resp
 
     def respond_confirm_relation_from_literature(self, content):
         """Confirm a protein-protein interaction given subject, object, verb."""

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -213,7 +213,7 @@ class MSA_Module(Bioagent):
         if not res_dict['done']:
             # Calling this success may be a bit ambitious.
             resp = KQMLPerformative('SUCCESS')
-            resp.set('finished', 'nil')
+            resp.set('status', 'WORKING')
             resp.set('relations-found', 'nil')
             resp.set('dump-limit', str(DUMP_LIMIT))
             return resp
@@ -223,7 +223,7 @@ class MSA_Module(Bioagent):
 
         rest_resp = res_dict['result']
         resp = KQMLPerformative('SUCCESS')
-        resp.set('finished', 't')
+        resp.set('status', 'FINISHED')
         resp.set('relations-found', str(len(rest_resp.statements)))
         resp.set('dump-limit', str(DUMP_LIMIT))
         return resp

--- a/bioagents/tests/dtda_test.py
+++ b/bioagents/tests/dtda_test.py
@@ -5,9 +5,10 @@ from bioagents.dtda.dtda_module import DTDA_Module
 from bioagents.tests.util import ekb_from_text, ekb_kstring_from_text, \
     get_request
 from bioagents.tests.integration import _IntegrationTest
+from nose.plugins.attrib import attr
+
 
 # DTDA unit tests
-
 
 def test_mutation_statistics():
     d = DTDA()
@@ -40,6 +41,7 @@ _kras = _create_agent('KRAS', hgnc='6407')
 _tgfbr1 = _create_agent('TGFBR1', hgnc='11772')
 
 
+@attr('nonpublic')
 def test_is_nominal_target():
     d = DTDA()
     for vem in _vems:
@@ -49,12 +51,14 @@ def test_is_nominal_target():
         assert not is_target
 
 
+@attr('nonpublic')
 def test_is_nominal_target_dash():
     d = DTDA()
     is_target = d.is_nominal_drug_target(_alk_drug, _tgfbr1)
     assert is_target
 
 
+@attr('nonpublic')
 def test_find_drug_targets1():
     d = DTDA()
     for vem in _vems:
@@ -63,6 +67,7 @@ def test_find_drug_targets1():
         assert any(target == 'BRAF' for target in targets), targets
 
 
+@attr('nonpublic')
 def test_find_drug_targets2():
     d = DTDA()
     targets = d.find_drug_targets(_alk_drug)
@@ -87,6 +92,7 @@ class _TestFindTargetDrug(_IntegrationTest):
         assert len(output.get('drugs')) == 9, output
 
 
+@attr('nonpublic')
 class TestFindTargetDrug1(_TestFindTargetDrug):
     target = 'BRAF'
 
@@ -95,6 +101,7 @@ class TestFindTargetDrug1(_TestFindTargetDrug):
         assert len(output.get('drugs')) >= 9, output
 
 
+@attr('nonpublic')
 class TestFindTargetDrug2(_TestFindTargetDrug):
     target = 'PAK4'
 
@@ -114,6 +121,7 @@ class TestFindTargetDrug2(_TestFindTargetDrug):
              % (pubchem_ids, drug_names, exp_pubchem_id))
 
 
+@attr('nonpublic')
 class TestFindTargetDrug3(_TestFindTargetDrug):
     target = 'KRAS'
 
@@ -122,6 +130,7 @@ class TestFindTargetDrug3(_TestFindTargetDrug):
         assert len(output.get('drugs')) == 0, output
 
 
+@attr('nonpublic')
 class TestFindTargetDrug4(_TestFindTargetDrug):
     target = 'JAK2'
 
@@ -130,6 +139,7 @@ class TestFindTargetDrug4(_TestFindTargetDrug):
         assert len(output.get('drugs')) >= 9, (len(output), output)
 
 
+@attr('nonpublic')
 class TestFindTargetDrug5(_TestFindTargetDrug):
     target = 'JAK1'
 
@@ -139,7 +149,7 @@ class TestFindTargetDrug5(_TestFindTargetDrug):
 
 
 # FIND-DRUG-TARGETS tests
-
+@attr('nonpublic')
 class TestFindDrugTargets1(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
@@ -158,6 +168,7 @@ class TestFindDrugTargets1(_IntegrationTest):
         assert any(target.gets('name') == 'BRAF' for target in targets), targets
 
 
+@attr('nonpublic')
 class TestFindDrugTargets2(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
@@ -192,6 +203,7 @@ class _TestIsDrugTarget(_IntegrationTest):
         return get_request(content), content
 
 
+@attr('nonpublic')
 class TestIsDrugTarget1(_TestIsDrugTarget):
     target = 'BRAF'
     drug = 'Vemurafenib'
@@ -201,6 +213,7 @@ class TestIsDrugTarget1(_TestIsDrugTarget):
         assert output.gets('is-target') == 'TRUE', output
 
 
+@attr('nonpublic')
 class TestIsDrugTarget2(_TestIsDrugTarget):
     target = 'BRAF'
     drug = 'dabrafenib'
@@ -209,7 +222,7 @@ class TestIsDrugTarget2(_TestIsDrugTarget):
         assert output.head() == 'SUCCESS', output
         assert output.gets('is-target') == 'TRUE', output
 
-
+@attr('nonpublic')
 class TestIsDrugTarget3(_TestIsDrugTarget):
     target = 'KRAS'
     drug = 'dabrafenib'
@@ -219,6 +232,7 @@ class TestIsDrugTarget3(_TestIsDrugTarget):
         assert output.gets('is-target') == 'FALSE', output
 
 
+@attr('nonpublic')
 class TestIsDrugTarget4(_TestIsDrugTarget):
     target = 'TGFBR1'
     drug = 'SB525334'
@@ -229,6 +243,7 @@ class TestIsDrugTarget4(_TestIsDrugTarget):
 
 
 # FIND-DISEASE-TARGETS tests
+@attr('nonpublic')
 class TestFindDiseaseTargets1(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
@@ -248,6 +263,7 @@ class TestFindDiseaseTargets1(_IntegrationTest):
         assert output.gets('functional-effect') == 'ACTIVE'
 
 
+@attr('nonpublic')
 class TestFindDiseaseTargets2(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
@@ -264,6 +280,7 @@ class TestFindDiseaseTargets2(_IntegrationTest):
         assert output.gets('functional-effect') == 'ACTIVE'
 
 
+@attr('nonpublic')
 class TestFindDiseaseTargets3(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
@@ -280,6 +297,7 @@ class TestFindDiseaseTargets3(_IntegrationTest):
 
 
 # FIND-TREATMENT tests
+@attr('nonpublic')
 class TestFindTreatment1(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
@@ -299,6 +317,7 @@ class TestFindTreatment1(_IntegrationTest):
         assert len(part2.get('drugs')) == 0
 
 
+@attr('nonpublic')
 class TestFindTreatment2(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)
@@ -317,6 +336,7 @@ class TestFindTreatment2(_IntegrationTest):
         assert len(part2.get('drugs')) == 0
 
 
+@attr('nonpublic')
 class TestFindTreatment3(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(DTDA_Module)

--- a/bioagents/tests/dtda_test.py
+++ b/bioagents/tests/dtda_test.py
@@ -10,6 +10,7 @@ from nose.plugins.attrib import attr
 
 # DTDA unit tests
 
+@attr('nonpublic')
 def test_mutation_statistics():
     d = DTDA()
     mutation_dict = \

--- a/bioagents/tests/dtda_test.py
+++ b/bioagents/tests/dtda_test.py
@@ -2,7 +2,8 @@ from indra.statements import Agent
 from kqml import KQMLList
 from bioagents.dtda.dtda import DTDA
 from bioagents.dtda.dtda_module import DTDA_Module
-from bioagents.tests.util import ekb_from_text, ekb_kstring_from_text, get_request
+from bioagents.tests.util import ekb_from_text, ekb_kstring_from_text, \
+    get_request
 from bioagents.tests.integration import _IntegrationTest
 
 # DTDA unit tests

--- a/bioagents/tests/mra_test.py
+++ b/bioagents/tests/mra_test.py
@@ -10,6 +10,7 @@ from bioagents.mra.mra import MRA, make_influence_map, make_contact_map
 from bioagents.mra.mra_module import MRA_Module, ekb_from_agent, get_target, \
     _get_matching_stmts, CAN_CHECK_STATEMENTS
 from nose.plugins.skip import SkipTest
+from nose.plugins.attrib import attr
 
 
 # ################
@@ -647,6 +648,7 @@ class TestModelMeetsGoalBuildOnly(_IntegrationTest):
         assert has_explanation == 'TRUE', has_explanation
 
 
+@attr('nonpublic')
 class TestModelGapSuggest(_IntegrationTest):
     def __init__(self, *args):
         super(self.__class__, self).__init__(MRA_Module)

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -4,6 +4,7 @@ from kqml.kqml_list import KQMLList
 from bioagents.tests.util import ekb_from_text, get_request
 from bioagents.tests.integration import _IntegrationTest
 from nose.plugins.skip import SkipTest
+from nose.plugins.attrib import attr
 
 
 if not msa_module.CAN_CHECK_STATEMENTS:
@@ -27,6 +28,7 @@ def _check_failure(msg, flaw, reason):
     assert msg.gets('reason') == reason
 
 
+@attr('webservice')
 def test_respond_phosphorylation_activating():
     "Test the msa_module response to a query regarding phosphorylation."
     msg = _get_message('PHOSPHORYLATION-ACTIVATING', 'MAP2K1', 'S', '222')
@@ -38,27 +40,32 @@ def test_respond_phosphorylation_activating():
         'MSA responded with wrong answer.'
 
 
+@attr('webservice')
 def test_no_target_failure():
     msg = _get_message('PHOSPHORYLATION-ACTIVATING')
     _check_failure(msg, 'no target given', 'MISSING_TARGET')
 
 
+@attr('webservice')
 def test_invalid_target_failure():
     msg = _get_message('PHOSPHORYLATION-ACTIVATING', 'JUND')
     _check_failure(msg, 'missing mechanism', 'MISSING_MECHANISM')
 
 
+@attr('webservice')
 def test_not_phosphorylation():
     msg = _get_message('BOGUS-ACTIVATING', 'MAP2K1', 'S', '222')
     _check_failure(msg, 'getting a bogus action', 'MISSING_MECHANISM')
 
 
+@attr('webservice')
 def test_not_activating():
     msg = _get_message('PHOSPHORYLATION-INHIBITING', 'MAP2K1', 'S', '222')
     _check_failure(msg, 'getting inhibition instead of activation',
                    'MISSING_MECHANISM')
 
 
+@attr('webservice')
 def test_no_activity_given():
     msg = _get_message('')
     _check_failure(msg, 'getting no activity type', 'UNKNOWN_ACTION')
@@ -95,6 +102,7 @@ class _TestMsaGeneralLookup(_IntegrationTest):
         assert len(prov_tells) == 1, prov_tells
 
 
+@attr('webservice')
 class TestMSATypeAndTarget(_TestMsaGeneralLookup):
     def create_type_and_target(self):
         return self._get_content('FIND-RELATIONS-FROM-LITERATURE',
@@ -106,6 +114,7 @@ class TestMSATypeAndTarget(_TestMsaGeneralLookup):
         return self._check_find_response(output)
 
 
+@attr('webservice')
 class TestMSATypeAndSource(_TestMsaGeneralLookup):
     def create_type_and_source(self):
         return self._get_content('FIND-RELATIONS-FROM-LITERATURE',
@@ -117,6 +126,7 @@ class TestMSATypeAndSource(_TestMsaGeneralLookup):
         return self._check_find_response(output)
 
 
+@attr('webservice')
 class TestMSAConfirm1(_TestMsaGeneralLookup):
     def create_message(self):
         return self._get_content('CONFIRM-RELATION-FROM-LITERATURE',
@@ -128,6 +138,7 @@ class TestMSAConfirm1(_TestMsaGeneralLookup):
         return self._check_find_response(output)
 
 
+@attr('webservice')
 class TestMSAConfirm2(_TestMsaGeneralLookup):
     def create_message(self):
         return self._get_content('CONFIRM-RELATION-FROM-LITERATURE',
@@ -139,6 +150,7 @@ class TestMSAConfirm2(_TestMsaGeneralLookup):
         return self._check_find_response(output)
 
 
+@attr('webservice')
 class TestMsaPaperGraph(_IntegrationTest):
     def __init__(self, *args, **kwargs):
         super(TestMsaPaperGraph, self).__init__(msa_module.MSA_Module)
@@ -168,6 +180,7 @@ class TestMsaPaperGraph(_IntegrationTest):
         return
 
 
+@attr('webservice')
 class TestMsaProvenance(_IntegrationTest):
     """Test that TRA can correctly run a model."""
     def __init__(self, *args, **kwargs):
@@ -209,6 +222,7 @@ class TestMsaProvenance(_IntegrationTest):
         return
 
 
+@attr('webservice')
 def test_msa_paper_retrieval_failure():
     raise SkipTest("This feature is currently not available.")
     content = KQMLList('GET-PAPER-MODEL')

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -28,7 +28,7 @@ def _check_failure(msg, flaw, reason):
     assert msg.gets('reason') == reason
 
 
-@attr('webservice')
+@attr('nonpublic')
 def test_respond_phosphorylation_activating():
     "Test the msa_module response to a query regarding phosphorylation."
     msg = _get_message('PHOSPHORYLATION-ACTIVATING', 'MAP2K1', 'S', '222')
@@ -40,32 +40,32 @@ def test_respond_phosphorylation_activating():
         'MSA responded with wrong answer.'
 
 
-@attr('webservice')
+@attr('nonpublic')
 def test_no_target_failure():
     msg = _get_message('PHOSPHORYLATION-ACTIVATING')
     _check_failure(msg, 'no target given', 'MISSING_TARGET')
 
 
-@attr('webservice')
+@attr('nonpublic')
 def test_invalid_target_failure():
     msg = _get_message('PHOSPHORYLATION-ACTIVATING', 'JUND')
     _check_failure(msg, 'missing mechanism', 'MISSING_MECHANISM')
 
 
-@attr('webservice')
+@attr('nonpublic')
 def test_not_phosphorylation():
     msg = _get_message('BOGUS-ACTIVATING', 'MAP2K1', 'S', '222')
     _check_failure(msg, 'getting a bogus action', 'MISSING_MECHANISM')
 
 
-@attr('webservice')
+@attr('nonpublic')
 def test_not_activating():
     msg = _get_message('PHOSPHORYLATION-INHIBITING', 'MAP2K1', 'S', '222')
     _check_failure(msg, 'getting inhibition instead of activation',
                    'MISSING_MECHANISM')
 
 
-@attr('webservice')
+@attr('nonpublic')
 def test_no_activity_given():
     msg = _get_message('')
     _check_failure(msg, 'getting no activity type', 'UNKNOWN_ACTION')
@@ -102,7 +102,7 @@ class _TestMsaGeneralLookup(_IntegrationTest):
         assert len(prov_tells) == 1, prov_tells
 
 
-@attr('webservice')
+@attr('nonpublic')
 class TestMSATypeAndTarget(_TestMsaGeneralLookup):
     def create_type_and_target(self):
         return self._get_content('FIND-RELATIONS-FROM-LITERATURE',
@@ -114,7 +114,7 @@ class TestMSATypeAndTarget(_TestMsaGeneralLookup):
         return self._check_find_response(output)
 
 
-@attr('webservice')
+@attr('nonpublic')
 class TestMSATypeAndSource(_TestMsaGeneralLookup):
     def create_type_and_source(self):
         return self._get_content('FIND-RELATIONS-FROM-LITERATURE',
@@ -126,7 +126,7 @@ class TestMSATypeAndSource(_TestMsaGeneralLookup):
         return self._check_find_response(output)
 
 
-@attr('webservice')
+@attr('nonpublic')
 class TestMSAConfirm1(_TestMsaGeneralLookup):
     def create_message(self):
         return self._get_content('CONFIRM-RELATION-FROM-LITERATURE',
@@ -138,7 +138,7 @@ class TestMSAConfirm1(_TestMsaGeneralLookup):
         return self._check_find_response(output)
 
 
-@attr('webservice')
+@attr('nonpublic')
 class TestMSAConfirm2(_TestMsaGeneralLookup):
     def create_message(self):
         return self._get_content('CONFIRM-RELATION-FROM-LITERATURE',
@@ -150,7 +150,7 @@ class TestMSAConfirm2(_TestMsaGeneralLookup):
         return self._check_find_response(output)
 
 
-@attr('webservice')
+@attr('nonpublic')
 class TestMsaPaperGraph(_IntegrationTest):
     def __init__(self, *args, **kwargs):
         super(TestMsaPaperGraph, self).__init__(msa_module.MSA_Module)
@@ -180,7 +180,7 @@ class TestMsaPaperGraph(_IntegrationTest):
         return
 
 
-@attr('webservice')
+@attr('nonpublic')
 class TestMsaProvenance(_IntegrationTest):
     """Test that TRA can correctly run a model."""
     def __init__(self, *args, **kwargs):
@@ -222,7 +222,7 @@ class TestMsaProvenance(_IntegrationTest):
         return
 
 
-@attr('webservice')
+@attr('nonpublic')
 def test_msa_paper_retrieval_failure():
     raise SkipTest("This feature is currently not available.")
     content = KQMLList('GET-PAPER-MODEL')

--- a/bioagents/tests/test_model_diagnoser.py
+++ b/bioagents/tests/test_model_diagnoser.py
@@ -1,6 +1,8 @@
 from indra.statements import *
 from bioagents.mra.model_diagnoser import ModelDiagnoser
 from indra.assemblers.pysb import PysbAssembler
+from nose.plugins.attrib import attr
+
 
 drug = Agent('PLX4720')
 raf = Agent('RAF', db_refs={'FPLX': 'RAF'})
@@ -52,6 +54,7 @@ def test_check_model():
     assert path[1] == model_stmts[1]
 
 
+@attr('nonpublic')
 def test_propose_statement():
     jun = Agent('JUN', db_refs={'HGNC':'6204', 'UP': 'P05412'})
     explain = Activation(raf, jun)
@@ -73,7 +76,3 @@ def test_propose_statement():
     stmt_prop = result.get('connect_stmts')
     assert stmt_prop == (model_stmts[0], model_stmts[1])
     stmt_suggestions = md.suggest_statements(*stmt_prop)
-
-
-if __name__ == '__main__':
-    test_propose_statement()


### PR DESCRIPTION
This PR attempts to avoid problems with database connectivity or over-load by off-loading provenance tasks into the background (MRA, MSA) and by somewhat more gracefully handling timeouts (DTDA). A full handling of the DTDA would require implementing a new error message and its handling, which is not done here, though some essential groundwork is laid.