### PR TITLE
Reorganize Image Stashing

### DIFF
--- a/bioagents/__init__.py
+++ b/bioagents/__init__.py
@@ -1,4 +1,9 @@
 import logging
+from os import path
+from datetime import datetime
+
+from bioagents.settings import IMAGE_DIR, TIMESTAMP_PICS
+
 logging.basicConfig(format='%(levelname)s: %(name)s - %(message)s',
                     level=logging.INFO)
 logger = logging.getLogger('Bioagents')
@@ -190,3 +195,15 @@ def make_evidence_html(stmt_list, limit=5):
     entries_list = ['<li>%s</li>' % entry for entry in entries]
     evidence_html = '<ul>%s</ul>' % ('\n'.join(entries_list))
     return evidence_html
+
+
+def get_img_path(img_name):
+    """Get a full path for the given image name.
+
+    The name will also have a timestamp added if settings.TIMESTAMP_PICS is
+    True. The timestamp, if applied, will prepend the name.
+    """
+    if TIMESTAMP_PICS:
+        date_str = datetime.now().strftime('%Y%m%d%H%M%S')
+        img_name = '%s_%s' % (date_str, img_name)
+    return path.join(IMAGE_DIR, img_name)

--- a/bioagents/mra/mra.py
+++ b/bioagents/mra/mra.py
@@ -358,6 +358,14 @@ def make_diagrams(pysb_model, model_id, current_model, context=None):
     return diagrams
 
 
+def make_pic_name(model_id, token):
+    """Create a standardized picture name."""
+    return '%s_model%d_%s' % (
+        datetime.now().strftime('%Y%m%d%H%M%S'),
+        model_id,
+        token
+        )
+
 def make_sbgn(pysb_model, model_id):
     pa = PysbAssembler()
     pa.model = pysb_model
@@ -375,10 +383,7 @@ def draw_influence_map(pysb_model, model_id):
     """Generate a Kappa influence map, draw it and save it as a PNG."""
     try:
         im = make_influence_map(pysb_model)
-        fname = '%s_model%d_im' % (
-            datetime.now().strftime('%Y%m%d%H%M%S'),
-            model_id
-            )
+        fname = make_pic_name(model_id, 'im')
         abs_path = os.path.abspath(os.getcwd())
         full_path = os.path.join(abs_path, fname + '.png')
         im_agraph = networkx.nx_agraph.to_agraph(im)
@@ -409,7 +414,7 @@ def make_influence_map(pysb_model):
 def draw_contact_map(pysb_model, model_id):
     try:
         cm = make_contact_map(pysb_model)
-        fname = 'model%d_cm' % model_id
+        fname = make_pic_name(model_id, 'cm')
         abs_path = os.path.abspath(os.getcwd())
         full_path = os.path.join(abs_path, fname + '.png')
         cm.draw(full_path, prog='dot')
@@ -436,7 +441,7 @@ def draw_reaction_network(pysb_model, model_id):
     try:
         for m in pysb_model.monomers:
             pysb_assembler.set_extended_initial_condition(pysb_model, m, 0)
-        fname = 'model%d_rxn' % model_id
+        fname = make_pic_name(model_id, 'rxn')
         diagram_dot = render_reactions.run(pysb_model)
     # TODO: use specific PySB/BNG exceptions and handle them
     # here to show meaningful error messages

--- a/bioagents/mra/mra.py
+++ b/bioagents/mra/mra.py
@@ -15,8 +15,7 @@ import kappy
 
 from indra.sources import trips
 from indra.statements import Complex, Activation, IncreaseAmount, \
-                            AddModification, stmts_from_json
-from indra.databases import uniprot_client
+    stmts_from_json
 from indra.preassembler.hierarchy_manager import hierarchies
 from indra.assemblers.pysb import assembler as pysb_assembler
 from indra.assemblers.pysb import PysbAssembler
@@ -26,7 +25,6 @@ from pysb.tools import render_reactions
 from pysb.export import export
 from indra.util.kappa_util import im_json_to_graph, cm_json_to_graph
 from bioagents.mra.sbgn_colorizer import SbgnColorizer
-import pickle
 from bioagents.mra.model_diagnoser import ModelDiagnoser
 logger = logging.getLogger('MRA')
 
@@ -366,6 +364,7 @@ def make_pic_name(model_id, token):
         token
         )
 
+
 def make_sbgn(pysb_model, model_id):
     pa = PysbAssembler()
     pa.model = pysb_model
@@ -469,6 +468,7 @@ def stmt_exists(stmts, stmt):
             return True
     return False
 
+
 def make_ccle_map():
     fname = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                          '../resources/ccle_lines.txt')
@@ -477,5 +477,6 @@ def make_ccle_map():
 
     ccle_map = {c.split('_')[0]: c for c in clines}
     return ccle_map
+
 
 ccle_map = make_ccle_map()

--- a/bioagents/mra/mra.py
+++ b/bioagents/mra/mra.py
@@ -9,7 +9,10 @@ import json
 import logging
 import networkx
 import subprocess
+from datetime import datetime
+
 import kappy
+
 from indra.sources import trips
 from indra.statements import Complex, Activation, IncreaseAmount, \
                             AddModification, stmts_from_json
@@ -19,12 +22,12 @@ from indra.assemblers.pysb import assembler as pysb_assembler
 from indra.assemblers.pysb import PysbAssembler
 from pysb.bng import BngInterfaceError
 from pysb.tools import render_reactions
+
 from pysb.export import export
 from indra.util.kappa_util import im_json_to_graph, cm_json_to_graph
 from bioagents.mra.sbgn_colorizer import SbgnColorizer
 import pickle
 from bioagents.mra.model_diagnoser import ModelDiagnoser
-
 logger = logging.getLogger('MRA')
 
 
@@ -372,7 +375,10 @@ def draw_influence_map(pysb_model, model_id):
     """Generate a Kappa influence map, draw it and save it as a PNG."""
     try:
         im = make_influence_map(pysb_model)
-        fname = 'model%d_im' % model_id
+        fname = '%s_model%d_im' % (
+            datetime.now().strftime('%Y%m%d%H%M%S'),
+            model_id
+            )
         abs_path = os.path.abspath(os.getcwd())
         full_path = os.path.join(abs_path, fname + '.png')
         im_agraph = networkx.nx_agraph.to_agraph(im)

--- a/bioagents/mra/mra.py
+++ b/bioagents/mra/mra.py
@@ -13,6 +13,7 @@ from datetime import datetime
 
 import kappy
 
+from bioagents import get_img_path
 from indra.sources import trips
 from indra.statements import Complex, Activation, IncreaseAmount, \
     stmts_from_json
@@ -358,11 +359,8 @@ def make_diagrams(pysb_model, model_id, current_model, context=None):
 
 def make_pic_name(model_id, token):
     """Create a standardized picture name."""
-    return '%s_model%d_%s' % (
-        datetime.now().strftime('%Y%m%d%H%M%S'),
-        model_id,
-        token
-        )
+    s = 'model%d_%s' % (model_id, token)
+    return get_img_path(s)
 
 
 def make_sbgn(pysb_model, model_id):

--- a/bioagents/qca/qca.py
+++ b/bioagents/qca/qca.py
@@ -1,13 +1,11 @@
 # QCA stands for qualitative causal agent whose task is to
 # identify causal paths within
 
-import os
-import logging
 import json
-import ndex2.client as nc
+import logging
 import requests
-import io
 import functools
+import ndex2.client as nc
 from enum import Enum
 from bioagents import BioagentException
 
@@ -204,7 +202,6 @@ class QCA(object):
 
         r = requests.post(url)
         return r
-
 
     def get_path_node_names(self, query_result):
         return None

--- a/bioagents/qca/qca_module.py
+++ b/bioagents/qca/qca_module.py
@@ -2,7 +2,7 @@ import os
 import sys
 import json
 import logging
-from bioagents import Bioagent
+from bioagents import Bioagent, get_img_path
 from kqml import KQMLList, KQMLString
 from .qca import QCA
 from indra.statements import stmts_from_json
@@ -92,9 +92,7 @@ class QCA_Module(Bioagent):
 
         paths_list = get_path_statements(results_list)
 
-
         self.report_paths_graph(paths_list)
-
 
         # Take the first one to report
         indra_edges = paths_list[0]
@@ -120,7 +118,7 @@ class QCA_Module(Bioagent):
         all_stmts = flatten(path_stmts)
         ga = GraphAssembler(all_stmts)
         ga.make_model()
-        resource = os.path.abspath('qca_paths.png')
+        resource = get_img_path('qca_paths.png')
         ga.save_pdf(resource)
         content = KQMLList('display-image')
         content.set('type', 'simulation')

--- a/bioagents/settings.py
+++ b/bioagents/settings.py
@@ -1,0 +1,15 @@
+__all__ = ['IMAGE_DIR', 'TIMESTAMP_PICS']
+
+from os import path, mkdir
+
+# Select the directory where images are stored. By default, it is in a
+# directory called `images` alongside this file. Note that if this file does
+# not exist, it will be created.
+IMAGE_DIR = path.abspath(path.join(path.dirname(__file__), 'images'))
+
+if not path.exists(IMAGE_DIR):
+    mkdir(IMAGE_DIR)
+
+# Choose whether images are given a timestamp. This can cause a buildup of
+# images over time, however it guarantees overall uniqueness over a single run.
+TIMESTAMP_PICS = False

--- a/bioagents/settings.py
+++ b/bioagents/settings.py
@@ -4,7 +4,7 @@ from os import path, mkdir
 
 # Select the directory where images are stored. By default, it is in a
 # directory called `images` alongside this file. Note that if this file does
-# not exist, it will be created.
+# not exist, it will be created. The path should be an absolute path.
 IMAGE_DIR = path.abspath(path.join(path.dirname(__file__), 'images'))
 
 if not path.exists(IMAGE_DIR):

--- a/bioagents/tra/tra.py
+++ b/bioagents/tra/tra.py
@@ -22,7 +22,8 @@ from pysb.integrate import Solver
 from pysb.export.kappa import KappaExporter
 import bioagents.tra.model_checker as mc
 import matplotlib
-from bioagents import BioagentException
+from bioagents import BioagentException, get_img_path
+
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 
@@ -166,8 +167,7 @@ class TRA(object):
         agent_str = english_assembler._assemble_agent_str(agent)
         plt.title('Simulation results for %s' % agent_str)
         plt.legend()
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        fig_path = os.path.join(dir_path, '%s.png' % obs_name)
+        fig_path = get_img_path(obs_name + '.png')
         plt.savefig(fig_path)
         return fig_path
 
@@ -196,11 +196,7 @@ class TRA(object):
         plt.ylabel('Amount (molecules)')
         agent_str = english_assembler._assemble_agent_str(agent)
         plt.title('Simulation results for %s' % agent_str)
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        fig_path = os.path.join(dir_path, '%s_%s.png' % (
-            datetime.now().strftime('%Y%m%d%H%M%S'),
-            obs_name
-            ))
+        fig_path = get_img_path(obs_name + '.png')
         plt.savefig(fig_path)
         return fig_path
 

--- a/bioagents/tra/tra.py
+++ b/bioagents/tra/tra.py
@@ -12,6 +12,7 @@ import numpy
 import logging
 from time import sleep
 from copy import deepcopy
+from datetime import datetime
 import sympy.physics.units as units
 import indra.statements as ist
 import indra.assemblers.pysb.assembler as pa
@@ -196,7 +197,10 @@ class TRA(object):
         agent_str = english_assembler._assemble_agent_str(agent)
         plt.title('Simulation results for %s' % agent_str)
         dir_path = os.path.dirname(os.path.realpath(__file__))
-        fig_path = os.path.join(dir_path, '%s.png' % obs_name)
+        fig_path = os.path.join(dir_path, '%s_%s.png' % (
+            datetime.now().strftime('%Y%m%d%H%M%S'),
+            obs_name
+            ))
         plt.savefig(fig_path)
         return fig_path
 


### PR DESCRIPTION
This PR:
- Allows images to have timestamps added to guarantee uniqueness
- Places all images in a single directory for easy retrieval
- Add a settings file, which currently stores options for the above two behaviors but could be extended further.