### PR TITLE
Move get disease

### DIFF
--- a/bioagents/dtda/dtda.py
+++ b/bioagents/dtda/dtda.py
@@ -7,7 +7,6 @@ import re
 import os
 import numpy
 import logging
-import xml.etree.ElementTree as ET
 
 from indra.sources.indra_db_rest import get_statements
 from indra.databases import cbio_client, hgnc_client
@@ -305,8 +304,8 @@ class Disease(object):
         return self.__repr__()
 
 
-def get_disease(disease_str):
-        term = ET.fromstring(disease_str).find('TERM')
+def get_disease(disease_ekb):
+        term = disease_ekb.find('TERM')
         disease_type = term.find('type').text
         if disease_type.startswith('ONT::'):
             disease_type = disease_type[5:].lower()

--- a/bioagents/dtda/dtda.py
+++ b/bioagents/dtda/dtda.py
@@ -315,7 +315,7 @@ def get_disease(disease_ekb):
             dbid_dict = {}
         else:
             dbname = drum_term.attrib['name']
-            dbid = term.attrib['dbid']
+            dbid = drum_term.attrib['dbid']
             dbids = dbid.split('|')
             dbid_dict = {k: v for k, v in [d.split(':') for d in dbids]}
         disease = Disease(disease_type, dbname, dbid_dict)

--- a/bioagents/dtda/dtda.py
+++ b/bioagents/dtda/dtda.py
@@ -7,6 +7,7 @@ import re
 import os
 import numpy
 import logging
+import xml.etree.ElementTree as ET
 
 from indra.sources.indra_db_rest import get_statements
 from indra.databases import cbio_client, hgnc_client
@@ -302,6 +303,24 @@ class Disease(object):
 
     def __str__(self):
         return self.__repr__()
+
+
+def get_disease(disease_str):
+        term = ET.fromstring(disease_str).find('TERM')
+        disease_type = term.find('type').text
+        if disease_type.startswith('ONT::'):
+            disease_type = disease_type[5:].lower()
+        drum_term = term.find('drum-terms/drum-term')
+        if drum_term is None:
+            dbname = term.find('name').text
+            dbid_dict = {}
+        else:
+            dbname = drum_term.attrib['name']
+            dbid = term.attrib['dbid']
+            dbids = dbid.split('|')
+            dbid_dict = {k: v for k, v in [d.split(':') for d in dbids]}
+        disease = Disease(disease_type, dbname, dbid_dict)
+        return disease
 
 
 def _convert_term(term):

--- a/bioagents/dtda/dtda_module.py
+++ b/bioagents/dtda/dtda_module.py
@@ -4,7 +4,7 @@ import xml.etree.ElementTree as ET
 from indra.sources.trips.processor import TripsProcessor
 from indra.statements import Agent
 from kqml import KQMLList
-from .dtda import DTDA, Disease, \
+from .dtda import DTDA, Disease, get_disease, \
                   DrugNotFoundException, DiseaseNotFoundException
 from bioagents import Bioagent
 from bioagents.resources.trips_ont_manager import trips_isa
@@ -89,7 +89,7 @@ class DTDA_Module(Bioagent):
         """Response content to find-disease-targets request."""
         try:
             disease_arg = content.gets('disease')
-            disease = self.get_disease(disease_arg)
+            disease = get_disease(disease_arg)
         except Exception as e:
             logger.error(e)
             reply = self.make_failure('INVALID_DISEASE')
@@ -124,7 +124,7 @@ class DTDA_Module(Bioagent):
         """Response content to find-treatment request."""
         try:
             disease_arg = content.gets('disease')
-            disease = self.get_disease(disease_arg)
+            disease = get_disease(disease_arg)
         except Exception as e:
             logger.error(e)
             reply = self.make_failure('INVALID_DISEASE')
@@ -182,24 +182,6 @@ class DTDA_Module(Bioagent):
         term_id = terms[0].attrib['id']
         agent = tp._get_agent_by_id(term_id, None)
         return agent
-
-    @staticmethod
-    def get_disease(disease_str):
-        term = ET.fromstring(disease_str).find('TERM')
-        disease_type = term.find('type').text
-        if disease_type.startswith('ONT::'):
-            disease_type = disease_type[5:].lower()
-        drum_term = term.find('drum-terms/drum-term')
-        if drum_term is None:
-            dbname = term.find('name').text
-            dbid_dict = {}
-        else:
-            dbname = drum_term.attrib['name']
-            dbid = term.attrib['dbid']
-            dbids = dbid.split('|')
-            dbid_dict = {k: v for k, v in [d.split(':') for d in dbids]}
-        disease = Disease(disease_type, dbname, dbid_dict)
-        return disease
 
 
 if __name__ == "__main__":

--- a/bioagents/dtda/dtda_module.py
+++ b/bioagents/dtda/dtda_module.py
@@ -89,7 +89,7 @@ class DTDA_Module(Bioagent):
         """Response content to find-disease-targets request."""
         try:
             disease_arg = content.gets('disease')
-            disease = get_disease(disease_arg)
+            disease = get_disease(ET.fromstring(disease_arg))
         except Exception as e:
             logger.error(e)
             reply = self.make_failure('INVALID_DISEASE')
@@ -124,7 +124,7 @@ class DTDA_Module(Bioagent):
         """Response content to find-treatment request."""
         try:
             disease_arg = content.gets('disease')
-            disease = get_disease(disease_arg)
+            disease = get_disease(ET.fromstring(disease_arg))
         except Exception as e:
             logger.error(e)
             reply = self.make_failure('INVALID_DISEASE')

--- a/bioagents/resources/cbio_efo_map.tsv
+++ b/bioagents/resources/cbio_efo_map.tsv
@@ -37,6 +37,8 @@ npc	nasopharyngeal carcinoma
 ov	ovarian carcinoma
 paac	pancreatic carcinoma
 paad	pancreatic carcinoma
+paac	pancreatic cancer
+paad	pancreatic cancer
 panet	pancreatic neuroendocrine tumor
 pcnsl	lymphoma
 pcpg	paraganglioma

--- a/bioagents/tests/dtda_test.py
+++ b/bioagents/tests/dtda_test.py
@@ -1,6 +1,7 @@
+import xml.etree.ElementTree as ET
 from indra.statements import Agent
 from kqml import KQMLList
-from bioagents.dtda.dtda import DTDA
+from bioagents.dtda.dtda import DTDA, get_disease
 from bioagents.dtda.dtda_module import DTDA_Module
 from bioagents.tests.util import ekb_from_text, ekb_kstring_from_text, \
     get_request
@@ -20,13 +21,13 @@ def test_mutation_statistics():
 
 def test_get_disease():
     disease_ekb = ekb_from_text('pancreatic cancer')
-    disease = DTDA_Module.get_disease(disease_ekb)
+    disease = get_disease(ET.fromstring(disease_ekb))
     disease_ekb = ekb_from_text('lung cancer')
-    disease = DTDA_Module.get_disease(disease_ekb)
+    disease = get_disease(ET.fromstring(disease_ekb))
     disease_ekb = ekb_from_text('diabetes')
-    disease = DTDA_Module.get_disease(disease_ekb)
+    disease = get_disease(ET.fromstring(disease_ekb))
     disease_ekb = ekb_from_text('common cold')
-    disease = DTDA_Module.get_disease(disease_ekb)
+    disease = get_disease(ET.fromstring(disease_ekb))
 
 
 def _create_agent(name, **refs):


### PR DESCRIPTION
This PR removes the get_disease static method out of the DTDA_Module class and makes it it's own top level function in dtda.py. get_disease is used for creating Disease objects from EKB xml. get_disease may now be used more naturally within clare, where it is helpful for implementing drug target capabilities. Pancreatic cancer has also been added to cbio_efo_map.tsv so that a test can pass for an example sentence containing this disease. 