### PR TITLE
MSA valid keys and prioritization

### DIFF
--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -55,13 +55,13 @@ class StatementQuery(object):
         A list of name spaces in order of preference (most preferable first).
         The special key !OTHER! can be used as a place holder for any other
         grounding not explicitly mentioned. If None, the default list will be
-        used: ['HGNC', 'FPLX', 'CHEBI', '!OTHER!', 'TEXT'].
+        used: ['HGNC', 'FPLX', 'CHEBI', '!OTHER!', 'TEXT', '!NAME!'].
     """
     def __init__(self, subj, obj, agents, verb, settings,
                  valid_name_spaces=None):
         self.entities = {}
         self._ns_keys = valid_name_spaces if valid_name_spaces is not None \
-            else ['HGNC', 'FPLX', 'CHEBI', '!OTHER!', 'TEXT']
+            else ['HGNC', 'FPLX', 'CHEBI', '!OTHER!', 'TEXT', '!NAME!']
         self.subj = subj
         self.subj_key = self.get_key(subj)
         self.obj = obj
@@ -96,6 +96,10 @@ class StatementQuery(object):
                     if key not in low_priority_keys:
                         dbn, dbi = key, value
                         break
+            # If we have name here, we use the Agent name for TEXT search
+            elif key == '!NAME!':
+                dbn, dbi = 'TEXT', agent.name
+                break
             # Otherwise, this is a regular key, and we just look for it in
             # the Agent's db_refs
             elif key in agent.db_refs:

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -54,7 +54,9 @@ class StatementQuery(object):
     valid_name_spaces : list[str] or None
         A list of name spaces in order of preference (most preferable first).
         The special key !OTHER! can be used as a place holder for any other
-        grounding not explicitly mentioned. If None, the default list will be
+        grounding not explicitly mentioned. The key !NAME! is  place holder
+        for the Agent name (that doesn't appear in db_refs).
+        If not provided, the following default list will be
         used: ['HGNC', 'FPLX', 'CHEBI', '!OTHER!', 'TEXT', '!NAME!'].
     """
     def __init__(self, subj, obj, agents, verb, settings,

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -52,15 +52,16 @@ class StatementQuery(object):
         A dictionary containing other parameters used by the
         IndraDbRestProcessor.
     valid_name_spaces : list[str] or None
-        A list of name spaces that are allowed as grounding, in order of
-        preference (most preferable first). If None, the default list will be
-        used: ['HGNC', 'FPLX', 'CHEBI', 'TEXT'].
+        A list of name spaces in order of preference (most preferable first).
+        The special key !OTHER! can be used as a place holder for any other
+        grounding not explicitly mentioned. If None, the default list will be
+        used: ['HGNC', 'FPLX', 'CHEBI', '!OTHER!', 'TEXT'].
     """
     def __init__(self, subj, obj, agents, verb, settings,
                  valid_name_spaces=None):
         self.entities = {}
         self._ns_keys = valid_name_spaces if valid_name_spaces is not None \
-            else ['HGNC', 'FPLX', 'CHEBI', 'TEXT']
+            else ['HGNC', 'FPLX', 'CHEBI', '!OTHER!', 'TEXT']
         self.subj = subj
         self.subj_key = self.get_key(subj)
         self.obj = obj
@@ -84,15 +85,28 @@ class StatementQuery(object):
         if agent is None:
             return None
 
-        # Get the key
-        for key in self._ns_keys:
-            if key in agent.db_refs.keys():
-                dbn = key
-                dbi = agent.db_refs[key]
+        dbn, dbi = None, None
+        # Iterate over all the keys in order
+        for idx, key in enumerate(self._ns_keys):
+            # If we hit OTHER, we need to make sure we only return on keys
+            # that don't appear in the tail part of the list
+            if key == '!OTHER!':
+                low_priority_keys = self._ns_keys[idx+1:]
+                for key, value in agent.db_refs.items():
+                    if key not in low_priority_keys:
+                        dbn, dbi = key, value
+                        break
+            # Otherwise, this is a regular key, and we just look for it in
+            # the Agent's db_refs
+            elif key in agent.db_refs:
+                dbn, dbi = key, agent.db_refs[key]
                 break
-        else:
-            raise EntityError("Could not get valid grounding (%s) for %s."
-                              % (', '.join(self._ns_keys), agent))
+
+        if dbn is None:
+            raise EntityError(("Could not get valid grounding (%s) for %s "
+                               "with db_refs=%s.")
+                               % (', '.join(self._ns_keys), agent,
+                                  agent.db_refs))
         self.entities[agent.name] = (dbn, dbi)
 
         return '%s@%s' % (dbi, dbn)

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -383,6 +383,16 @@ def test_msa_paper_retrieval_failure():
 
 
 @attr('nonpublic')
+def test_valid_keys_no_text():
+    # We test that an agent with just a PUBCHEM ID can still be queried
+    msa = MSA()
+    ag = Agent('vemurafenib', db_refs={'PUBCHEM': '42611257'})
+    finder = msa.find_mechanisms('from_source', ag)
+    stmts = finder.get_statements(block=True)
+    assert stmts
+
+
+@attr('nonpublic')
 def test_get_finder_agents():
     msa = MSA()
     ag = Agent('SOCS1', db_refs={'HGNC': '19383'})


### PR DESCRIPTION
This PR changes the logic by which the MSA determines valid db_refs keys in queries. The original issue is that before this PR, the MSA would reject valid Agent groundings that weren't 'HGNC', 'FPLX', 'CHEBI' and would go with 'TEXT' instead, or in case that wasn't available, thrown an exception (see `test_valid_keys_no_text` to reproduce this).

This PR relaxes these validity conditions, and instead treats the valid_name_spaces list as a prioritization order. It also adds two special keys to the list, !OTHER! (i.e., any other grounding not listed), and !NAME! (agent name, which is normally not in db_refs). With this change, any grounded agent will first be queried by one of its groundings (even if it's not explicitly listed), then by TEXT, and if even that is missing, by its Agent name.