### PR TITLE
MSA developments and entity type filter

### DIFF
--- a/bioagents/__init__.py
+++ b/bioagents/__init__.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from indra.assemblers.html import HtmlAssembler
 from indra.util.statement_presentation import group_and_sort_statements, \
-    make_string_from_sort_key, make_stmt_from_sort_key
+    make_string_from_sort_key, make_stmt_from_sort_key, stmt_to_english
 
 from bioagents.settings import IMAGE_DIR, TIMESTAMP_PICS
 

--- a/bioagents/__init__.py
+++ b/bioagents/__init__.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from indra.assemblers.html import HtmlAssembler
 from indra.util.statement_presentation import group_and_sort_statements, \
-    make_string_from_sort_key
+    make_string_from_sort_key, make_stmt_from_sort_key
 
 from bioagents.settings import IMAGE_DIR, TIMESTAMP_PICS
 

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -235,13 +235,12 @@ class StatementFinder(object):
                              % (type(other_role), other_role))
 
         # If the entities are not given, get them from the query itself
-        if entities is None:
-            entity_names = set(self.query.entities.values())
-        else:
-            entity_names = set(self.query.entities.values()) & \
-                set(self.query.get_agent_grounding(e) for e in entities)
+        query_entities = set(self.query.entities.values())
+        if entities:
+            query_entities &= set(self.query.get_agent_grounding(e)
+                                  for e in entities)
 
-        # Build up a dict of names, counting how often they occur.
+        # Build up a dict of groundings, counting how often they occur.
         counts = defaultdict(lambda: 0)
         oa_dict = defaultdict(list)
         ev_totals = self.get_ev_totals()
@@ -249,7 +248,7 @@ class StatementFinder(object):
         if not stmts:
             return None
         for stmt in stmts:
-            other_agents = self.get_other_agents_for_stmt(stmt, entity_names,
+            other_agents = self.get_other_agents_for_stmt(stmt, query_entities,
                                                           other_role)
             for ag in other_agents:
                 gr = self.query.get_agent_grounding(ag)
@@ -260,7 +259,7 @@ class StatementFinder(object):
             agent = Agent(agents[0].name, db_refs={dbn: dbi})
             return agent
 
-        # Create a list of names sorted with the most frequent first.
+        # Create a list of groundings sorted with the most frequent first.
         sorted_groundings = list(sorted(counts.keys(), key=lambda t: counts[t],
                                         reverse=True))
         other_agents = [get_aggregate_agent(oa_dict[gr], *gr) for gr in

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -240,12 +240,12 @@ class StatementFinder(object):
         stmts = self.get_statements(block)
         if not stmts:
             return None
-        for s in stmts:
-            other_agents = self.get_other_agents_for_stmt(entity_names,
+        for stmt in stmts:
+            other_agents = self.get_other_agents_for_stmt(stmt, entity_names,
                                                           other_role)
             for ag in other_agents:
                 gr = self.query.get_agent_grounding(ag)
-                counts[gr] += ev_totals[s.get_hash()]
+                counts[gr] += ev_totals[stmt.get_hash()]
                 oa_dict[gr].append(ag)
 
         def get_aggregate_agent(agents, dbn, dbi):
@@ -260,7 +260,7 @@ class StatementFinder(object):
         return other_agents
 
     @staticmethod
-    def get_other_agents_for_stmt(query_entities, other_role=None):
+    def get_other_agents_for_stmt(stmt, query_entities, other_role=None):
         """Return a list of other agents for a given statement."""
 
         def matches_none(ag):
@@ -268,17 +268,16 @@ class StatementFinder(object):
             entities."""
             if ag is None:
                 return False
-            for dbn, dbi in query_entities:
+            for dbi, dbn in query_entities:
                 if ag is not None and ag.db_refs.get(dbn) == dbi:
                     return False
             return True
 
         other_agents = []
-
         # If the role is None, look at all the agents.
-        ags = s.agent_list()
+        ags = stmt.agent_list()
         if other_role is None:
-            other_agents += [ag for ag in ages if matches_none(ag)]
+            other_agents += [ag for ag in ags if matches_none(ag)]
         # If the role is specified, look at just those agents.
         else:
             idx = 0 if other_role == 'subject' else 1

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -281,6 +281,39 @@ class StatementFinder(object):
                         sorted_groundings]
         return other_agents
 
+    @staticmethod
+    def get_other_agents_for_stmt(query_entities, other_role=None):
+        """Return a list of other agents for a given statement."""
+
+        def matches_none(ag):
+            """Return True if the given agent doesn't match any of the query
+            entities."""
+            if ag is None:
+                return False
+            for dbn, dbi in query_entities:
+                if ag is not None and ag.db_refs.get(dbn) == dbi:
+                    return False
+            return True
+
+        other_agents = []
+
+        # If the role is None, look at all the agents.
+        ags = s.agent_list()
+        if other_role is None:
+            other_agents += [ag for ag in ages if matches_none(ag)]
+        # If the role is specified, look at just those agents.
+        else:
+            idx = 0 if other_role == 'subject' else 1
+            if idx + 1 > len(ags):
+                raise ValueError('Could not apply role %s, not enough '
+                                 'agents: %s' % (other_role, ags))
+            ag = ags[idx]
+            if matches_none(ag):
+                other_agents.append(ag)
+
+        return other_agents
+
+
     def get_ev_totals(self):
         """Get a dictionary of evidence total counts from the processor."""
         # Getting statements applies any filters, so the counts are consistent
@@ -813,5 +846,3 @@ class MSA(object):
             raise ValueError("Invalid combination of entity arguments: "
                              "subject=%s, object=%s, agents=%s."
                              % (subject, object, agents))
-
-

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -652,7 +652,8 @@ class ComplexOneSide(StatementFinder):
                               params)
 
     def describe(self, max_names=20):
-        desc = "Overall, I found that %s can be in a complex with: "
+        desc = "Overall, I found that %s can be in a complex with: " % \
+               self.query.agents[0].name
         other_names = self.get_other_names(self.query.agents[0])
         desc += _join_list(other_names[:max_names])
         return desc

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -65,11 +65,11 @@ class StatementQuery(object):
         self._ns_keys = valid_name_spaces if valid_name_spaces is not None \
             else ['HGNC', 'FPLX', 'CHEBI', '!OTHER!', 'TEXT', '!NAME!']
         self.subj = subj
-        self.subj_key = self.get_key(subj)
+        self.subj_key = self.get_query_key(subj)
         self.obj = obj
-        self.obj_key = self.get_key(obj)
+        self.obj_key = self.get_query_key(obj)
         self.agents = agents
-        self.agent_keys = [self.get_key(e) for e in agents]
+        self.agent_keys = [self.get_query_key(e) for e in agents]
 
         self.verb = verb
         if verb in mod_map.keys():
@@ -82,7 +82,15 @@ class StatementQuery(object):
             raise EntityError("Did not get any usable entity constraints!")
         return
 
-    def get_key(self, agent):
+    def get_query_key(self, agent):
+        if agent is None:
+            return None
+        dbi, dbn = self.get_agent_grounding(agent)
+        self.entities[agent.name] = (dbi, dbn)
+        key = '%s@%s' % (dbi, dbn)
+        return key
+
+    def get_agent_grounding(self, agent):
         """If the entity is not already an agent, form an agent."""
         if agent is None:
             return None
@@ -113,9 +121,7 @@ class StatementQuery(object):
                                "with db_refs=%s.")
                                % (', '.join(self._ns_keys), agent,
                                   agent.db_refs))
-        self.entities[agent.name] = (dbn, dbi)
-
-        return '%s@%s' % (dbi, dbn)
+        return dbi, dbn
 
 
 class StatementFinder(object):

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -585,7 +585,8 @@ class FromSource(StatementFinder):
 
     def _filter_stmts(self, stmts):
         if self.query.ent_type:
-            stmts_out = self.filter_other_agent_type(stmts, ent_type,
+            stmts_out = self.filter_other_agent_type(stmts,
+                                                     self.query.ent_type,
                                                      other_role='object')
             return stmts_out
         else:

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -624,7 +624,8 @@ class ToTarget(StatementFinder):
         # First we filter for None objects
         stmts_out = [s for s in stmts if s.agent_list()[0] is not None]
         if self.query.ent_type:
-            stmts_out = self.filter_other_agent_type(stmts_out, ent_type,
+            stmts_out = self.filter_other_agent_type(stmts_out,
+                                                     self.query.ent_type,
                                                      other_role='subject')
         return stmts_out
 

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -268,10 +268,16 @@ class StatementFinder(object):
                     gr = self.query.get_agent_grounding(ag)
                     counts[gr] += ev_totals[s.get_hash()]
                     oa_dict[gr].append(ag)
+
+        def get_aggregate_agent(agents, dbn, dbi):
+            agent = Agent(agents[0].name, db_refs={dbn: dbi})
+            return agent
+
         # Create a list of names sorted with the most frequent first.
-        names = list(sorted(counts.keys(), key=lambda t: counts[t],
-                     reverse=True))
-        other_agents = [ag for name in names for ag in oa_dict[name]]
+        sorted_groundings = list(sorted(counts.keys(), key=lambda t: counts[t],
+                                        reverse=True))
+        other_agents = [get_aggregate_agent(oa_dict[gr], *gr) for gr in
+                        sorted_groundings]
         return other_agents
 
     def get_ev_totals(self):

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -292,9 +292,7 @@ class StatementFinder(object):
             if idx + 1 > len(ags):
                 raise ValueError('Could not apply role %s, not enough '
                                  'agents: %s' % (other_role, ags))
-            ag = ags[idx]
-            if matches_none(ag):
-                other_agents.append(ag)
+            other_agents.append(ags[idx])
 
         return other_agents
 

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -642,6 +642,15 @@ class ComplexOneSide(StatementFinder):
         desc += _join_list(other_names[:max_names])
         return desc
 
+    def _filter_stmts(self, stmts):
+        # First we filter for None objects
+        if self.query.ent_type:
+            stmts_out = self.filter_other_agent_type(stmts,
+                                                     self.query.ent_type)
+            return stmts_out
+        else:
+            return stmts
+
 
 class _Commons(StatementFinder):
     _role = NotImplemented

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -7,7 +7,7 @@ import logging
 from collections import defaultdict
 
 from bioagents import group_and_sort_statements, make_string_from_sort_key, \
-    make_stmt_from_sort_key
+    make_stmt_from_sort_key, stmt_to_english
 from indra import get_config
 from indra.statements import stmts_to_json, Agent, get_all_descendants
 from indra.sources import indra_db_rest as idbr
@@ -325,14 +325,8 @@ class StatementFinder(object):
 
     def get_summary(self, num=5):
         """List the top statements in plain English."""
-        # TODO: refactor to use get_summary_stmts and turn Statements into
-        # English here
-        stmts = self.get_statements()
-        sorted_groups = group_and_sort_statements(stmts, self.get_ev_totals())
-        lines = []
-        for key, verb, stmts in sorted_groups[:num]:
-            line = '<li>%s</li>' % make_string_from_sort_key(key, verb)
-            lines.append(line)
+        stmts = self.get_summary_stmts(num)
+        lines = ['<li>%s</li>' % stmt_to_english(stmt) for stmt in stmts]
 
         # Build the overall html.
         if lines:

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -6,7 +6,8 @@ import logging
 
 from collections import defaultdict
 
-from bioagents import group_and_sort_statements, make_string_from_sort_key
+from bioagents import group_and_sort_statements, make_string_from_sort_key, \
+    make_stmt_from_sort_key
 from indra import get_config
 from indra.statements import stmts_to_json, Agent, get_all_descendants
 from indra.sources import indra_db_rest as idbr
@@ -314,8 +315,18 @@ class StatementFinder(object):
         msg += self.get_html() + '\n'
         return msg
 
+    def get_summary_stmts(self, num=5):
+        stmts = self.get_statements()
+        sorted_groups = group_and_sort_statements(stmts, self.get_ev_totals())
+        summary_stmts = []
+        for key, verb, stmts in sorted_groups[:num]:
+            summary_stmts.append(make_stmt_from_sort_key(key, verb))
+        return summary_stmts
+
     def get_summary(self, num=5):
-        """List the top statements in plane english."""
+        """List the top statements in plain English."""
+        # TODO: refactor to use get_summary_stmts and turn Statements into
+        # English here
         stmts = self.get_statements()
         sorted_groups = group_and_sort_statements(stmts, self.get_ev_totals())
         lines = []

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -506,6 +506,14 @@ def test_from_source_entity_filter():
 
 @attr('nonpublic')
 def test_from_source_entity_filter():
+    finder = msa.ComplexOneSide(Agent('BRAF', db_refs={'HGNC': '1097'}),
+                                persist=False)
+    oa = finder.get_other_agents(block=True)
+    oa_names = [a.name for a in oa]
+    # Make sure we can get the query entity itself if it's another member of
+    # the complex
+    assert 'BRAF' in oa_names
+
     # Phosphatases
     finder = msa.ComplexOneSide(Agent('BRAF', db_refs={'HGNC': '1097'}),
                                 ent_type='phosphatase', persist=False)
@@ -513,3 +521,4 @@ def test_from_source_entity_filter():
     oa_names = [a.name for a in oa]
     assert 'RAF1' not in oa_names
     assert 'PTEN' in oa_names
+    assert 'BRAF' not in oa_names

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -406,7 +406,7 @@ def test_get_finder_agents():
 
     # The other names should be sorted with PIM1 first (most evidence)
     other_names = finder.get_other_names(ag)
-    assert other_names[0] == 'PIM1'
+    assert other_names[0] == 'PIM1', other_names
 
 
 @attr('nonpublic')

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -502,3 +502,14 @@ def test_from_source_entity_filter():
     assert 'MAPK1' in oa_names
     assert 'apoptosis' not in oa_names
     assert 'proliferation' not in oa_names
+
+
+@attr('nonpublic')
+def test_from_source_entity_filter():
+    # Phosphatases
+    finder = msa.ComplexOneSide(Agent('BRAF', db_refs={'HGNC': '1097'}),
+                                ent_type='phosphatase', persist=False)
+    oa = finder.get_other_agents(block=True)
+    oa_names = [a.name for a in oa]
+    assert 'RAF1' not in oa_names
+    assert 'PTEN' in oa_names

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -438,3 +438,35 @@ def test_to_target_ERK():
     finder = msa.ToTarget(Agent('ERK', db_refs={'FPLX': 'ERK'}), persist=False)
     stmts = finder.get_statements(block=True)
     assert not any(None in s.agent_list() for s in stmts), stmts
+
+
+@attr('nonpublic')
+def test_to_target_entity_filter():
+    # Kinases
+    finder = msa.ToTarget(Agent('MEK', db_refs={'FPLX': 'MEK'}),
+                          ent_type='kinase', persist=False)
+    oa = finder.get_other_agents(block=True)
+    oa_names = [a.name for a in oa]
+    # RAF1 as a kinase is in the list
+    assert 'RAF1' in oa_names
+    # RAS, which normally is in the list should not be since it's not a kinase
+    assert 'RAS' not in oa_names
+    assert 'ESR1' not in oa_names
+
+    # Transcription factors
+    finder = msa.ToTarget(Agent('MEK', db_refs={'FPLX': 'MEK'}),
+                          ent_type='transcription factor', persist=False)
+    oa = finder.get_other_agents(block=True)
+    oa_names = [a.name for a in oa]
+    assert 'ESR1' in oa_names
+    assert 'RAF1' not in oa_names
+
+    # Proteins
+    finder = msa.ToTarget(Agent('MEK', db_refs={'FPLX': 'MEK'}),
+                          ent_type='protein', persist=False)
+    oa = finder.get_other_agents(block=True)
+    oa_names = [a.name for a in oa]
+    assert 'ESR1' in oa_names
+    assert 'RAF1' in oa_names
+    assert 'U0126' not in oa_names
+    assert 'trametinib' not in oa_names

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -470,3 +470,35 @@ def test_to_target_entity_filter():
     assert 'RAF1' in oa_names
     assert 'U0126' not in oa_names
     assert 'trametinib' not in oa_names
+
+
+@attr('nonpublic')
+def test_from_source_entity_filter():
+    # Kinases
+    finder = msa.FromSource(Agent('MEK', db_refs={'FPLX': 'MEK'}),
+                            ent_type='kinase', persist=False)
+    oa = finder.get_other_agents(block=True)
+    oa_names = [a.name for a in oa]
+    # RAF1 as a kinase is in the list
+    assert 'MAPK1' in oa_names
+    # RAS, which normally is in the list should not be since it's not a kinase
+    assert 'apoptosis' not in oa_names
+    assert 'RAS' not in oa_names
+
+    # Transcription factors
+    finder = msa.FromSource(Agent('MEK', db_refs={'FPLX': 'MEK'}),
+                            ent_type='transcription factor', persist=False)
+    oa = finder.get_other_agents(block=True)
+    oa_names = [a.name for a in oa]
+    assert 'ESR1' in oa_names
+    assert 'RAF1' not in oa_names
+
+    # Proteins
+    finder = msa.FromSource(Agent('MEK', db_refs={'FPLX': 'MEK'}),
+                            ent_type='protein', persist=False)
+    oa = finder.get_other_agents(block=True)
+    oa_names = [a.name for a in oa]
+    assert 'ERK' in oa_names
+    assert 'MAPK1' in oa_names
+    assert 'apoptosis' not in oa_names
+    assert 'proliferation' not in oa_names


### PR DESCRIPTION
This PR adds a new feature which allows filtering query results by the type of "other" entities (for instance, return only Statements in which the subject is a kinase for a ToTarget query). In conjunction with this, the PR makes the following changes:
- Add a new ent_type argument to StatementQuery driving the filter described above
- Split get_key into get_agent_grounding and get_query_key to expose get_agent_grounding
- Change get_other_agents to use grounding instead of name and refactor to expose single Statement level method to get other agents
- Refactor get_summary to expose get_summary_stmts that can be called from outside if we want to get Statements instead of NL directly
