### PR TITLE
Add option to filter results by a list of agents.

### DIFF
--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -193,7 +193,10 @@ class StatementFinder(object):
 
                 # Look for a match in any of the statements' agents.
                 for agent in stmt.agent_list():
-                    if agent.db_resf[dbi] == dbn:
+                    if agent is None:
+                        continue
+
+                    if agent.db_refs.get(dbn) == dbi:
                         filtered_stmts.append(stmt)
                         break  # found one.
                 else:

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -516,6 +516,9 @@ class Neighborhood(StatementFinder):
 
 class Activeforms(StatementFinder):
     def _regularize_input(self, entity, **params):
+        if 'filter_agents' in params.keys():
+            logger.warning("Parameter `filter_agents` is not meaningful for "
+                           "Activeforms or PhosActiveforms.")
         return StatementQuery(None, None, [entity], 'ActiveForm', None, params)
 
 
@@ -566,6 +569,9 @@ class PhosActiveforms(Activeforms):
 
 class BinaryDirected(StatementFinder):
     def _regularize_input(self, source, target, verb=None, **params):
+        if 'filter_agents' in params.keys():
+            logger.warning("Parameter `filter_agents` is not meaningful for "
+                           "Binary queries.")
         return StatementQuery(source, target, [], verb, None, params)
 
     def describe(self, limit=None):
@@ -582,6 +588,9 @@ class BinaryDirected(StatementFinder):
 
 class BinaryUndirected(StatementFinder):
     def _regularize_input(self, entity1, entity2, **params):
+        if 'filter_agents' in params.keys():
+            logger.warning("Parameter `filter_agents` is not meaningful for "
+                           "Binary queries.")
         return StatementQuery(None, None, [entity1, entity2], None, None,
                               params)
 

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -55,7 +55,7 @@ class StatementQuery(object):
         An entity type e.g., 'protein', 'kinase' describing the type of
         entities that are of interest as other agents in the resulting
         statements.
-    settings : dict
+    params : dict
         A dictionary containing other parameters used by the
         IndraDbRestProcessor.
     valid_name_spaces : list[str] or None
@@ -66,8 +66,8 @@ class StatementQuery(object):
         If not provided, the following default list will be
         used: ['HGNC', 'FPLX', 'CHEBI', '!OTHER!', 'TEXT', '!NAME!'].
     """
-    def __init__(self, subj, obj, agents, verb, ent_type, filter_agents,
-                 settings, valid_name_spaces=None):
+    def __init__(self, subj, obj, agents, verb, ent_type, params,
+                 valid_name_spaces=None):
         self.entities = {}
         self._ns_keys = valid_name_spaces if valid_name_spaces is not None \
             else ['HGNC', 'FPLX', 'CHEBI', '!OTHER!', 'TEXT', '!NAME!']
@@ -85,9 +85,9 @@ class StatementQuery(object):
             self.stmt_type = verb
 
         self.ent_type = ent_type
-        self.filter_agents = filter_agents
+        self.filter_agents = params.pop('filter_agents', [])
 
-        self.settings = settings
+        self.settings = params
         if not self.subj_key and not self.obj_key and not self.agent_keys:
             raise EntityError("Did not get any usable entity constraints!")
         return
@@ -179,6 +179,9 @@ class StatementFinder(object):
 
     def _filter_stmts_for_agents(self, stmts):
         """Internal method to filter statements involving particular agents."""
+        if not self.query.filter_agents:
+            return stmts
+
         filtered_stmts = []
         for stmt in stmts:
 

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -799,6 +799,7 @@ class _Commons(StatementFinder):
             self._statements = [s for data in self.commons.values()
                                 for s_list in data.values()
                                 for s in s_list]
+        self._statements = self._filter_stmts_for_agents(self._statements)
         return self._statements
 
     def get_common_entities(self):

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -521,7 +521,7 @@ def _erk():
 
 
 @attr('nonpublic')
-def test_from_source_entity_filter():
+def test_complex_one_side_entity_filter():
     finder = msa.ComplexOneSide(_braf(), persist=False)
     oa = finder.get_other_agents(block=True)
     oa_names = [a.name for a in oa]

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -504,10 +504,25 @@ def test_from_source_entity_filter():
     assert 'proliferation' not in oa_names
 
 
+def _braf():
+    return Agent('BRAF', db_refs={'HGNC': '1097'})
+
+
+def _kras():
+    return Agent('KRAS', db_refs={'HGNC': '6407'})
+
+
+def _mek():
+    return Agent('MEK', db_refs={'FPLX': 'MEK'})
+
+
+def _erk():
+    return Agent('ERK', db_refs={'FPLX': 'ERK'})
+
+
 @attr('nonpublic')
 def test_from_source_entity_filter():
-    finder = msa.ComplexOneSide(Agent('BRAF', db_refs={'HGNC': '1097'}),
-                                persist=False)
+    finder = msa.ComplexOneSide(_braf(), persist=False)
     oa = finder.get_other_agents(block=True)
     oa_names = [a.name for a in oa]
     # Make sure we can get the query entity itself if it's another member of
@@ -515,10 +530,42 @@ def test_from_source_entity_filter():
     assert 'BRAF' in oa_names
 
     # Phosphatases
-    finder = msa.ComplexOneSide(Agent('BRAF', db_refs={'HGNC': '1097'}),
-                                ent_type='phosphatase', persist=False)
+    finder = msa.ComplexOneSide(_braf(), ent_type='phosphatase', persist=False)
     oa = finder.get_other_agents(block=True)
     oa_names = [a.name for a in oa]
     assert 'RAF1' not in oa_names
     assert 'PTEN' in oa_names
     assert 'BRAF' not in oa_names
+
+
+@attr('nonpublic')
+def test_neighbors_agent_filter():
+    finder = msa.Neighborhood(_braf(), filter_agents=[_mek(), _erk()])
+    stmts = finder.get_statements(block=True)
+    assert len(stmts)
+    for stmt in stmts:
+        ag_names = {ag.name for ag in stmt.agent_list() if ag is not None}
+        assert ag_names & {'ERK', 'MEK'}
+
+
+@attr('nonpublic')
+def test_upstreams_agent_filter():
+    finder = msa.CommonUpstreams(_mek(), _erk(),
+                                 filter_agents=[_braf(), _kras()])
+    stmts = finder.get_statements(block=True)
+    assert len(stmts)
+    exp_ags = {'BRAF', 'KRAS'}
+    for stmt in stmts:
+        ag_names = {ag.name for ag in stmt.agent_list() if ag is not None}
+        assert ag_names & exp_ags, ag_names - exp_ags - {'MEK', 'ERK'}
+
+
+@attr('nonpublic', 'slow')
+def test_to_target_agent_filter():
+    finder = msa.ToTarget(_erk(), filter_agents=[_mek(), _braf(), _kras()])
+    stmts = finder.get_statements()
+    assert len(stmts)
+    exp_ags = {'MEK', 'BRAF', 'KRAS'}
+    for stmt in stmts:
+        ag_names = {ag.name for ag in stmt.agent_list() if ag is not None}
+        assert ag_names & exp_ags, ag_names - exp_ags - {'ERK'}


### PR DESCRIPTION
Adds a `filter_agents` parameter that takes a list of agents which will be used to winnow down the resulting search to only include statements that include those agents (post-query).