### PR TITLE
Improvements to MSA searches and summaries

### DIFF
--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -405,10 +405,10 @@ class StatementFinder(object):
         return summary_stmts
 
     def get_stmt_types(self):
-        """Get the set of statement types found in the body of statements."""
-        # TODO: this could be sorted by total evidence for each stmt type
+        """Return the sorted set of types found in the body of statements."""
         stmts = self.get_statements()
         evs = self.get_ev_totals()
+        # We count the evidence for each type of statement
         counts = {}
         for stmt in stmts:
             stmt_type = stmt.__class__.__name__.lower()
@@ -417,6 +417,7 @@ class StatementFinder(object):
                 counts[stmt_type] += ev
             else:
                 counts[stmt_type] = ev
+        # We finally sort by decreasing evidence count
         sorted_stmt_types = [k for k, v in sorted(counts.items(),
                                                   key=lambda x: x[1],
                                                   reverse=True)]
@@ -646,7 +647,7 @@ class FromSource(StatementFinder):
 
     def describe(self, limit=10):
         if self.query.stmt_type is None:
-            verb_wrap = ' can be affected by '
+            verb_wrap = ' can affect '
             ps = super(FromSource, self).describe(limit=limit)
         else:
             verb_wrap = ' can have the effect of %s on ' % self.query.stmt_type

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -11,7 +11,8 @@ from indra.util.statement_presentation import group_and_sort_statements, \
 from bioagents.biosense.biosense import _read_kinases, _read_phosphatases, \
     _read_tfs
 from indra import get_config
-from indra.statements import stmts_to_json, Agent, get_all_descendants
+from indra.statements import Statement, stmts_to_json, Agent, \
+    get_all_descendants
 from indra.sources import indra_db_rest as idbr
 
 from indra.assemblers.html import HtmlAssembler
@@ -20,14 +21,24 @@ from indra.assemblers.english.assembler import _join_list, statement_base_verb
 
 logger = logging.getLogger('MSA')
 
-mod_map = {'demethylate': 'Demethylation',
-           'methylate': 'Methylation',
-           'phosphorylate': 'Phosphorylation',
-           'dephosphorylate': 'Dephosphorylation',
-           'ubiquitinate': 'Ubiquitination',
-           'deubiquitinate': 'Deubiquitination',
-           'inhibit': 'Inhibition',
-           'activate': 'Activation'}
+
+def _build_mod_map():
+    stmts = get_all_descendants(Statement)
+    mod_map = {}
+    non_binary = ('hasactivity', 'activeform', 'selfmodification',
+                  'autophosphorylation', 'transphosphorylation',
+                  'event', 'unresolved', 'association', 'complex')
+    for stmt in stmts:
+        name = stmt.__name__
+        if name.lower() in non_binary:
+            continue
+        base_verb = statement_base_verb(name.lower())
+        mod_map[base_verb] = name
+    return mod_map
+
+
+mod_map = _build_mod_map()
+
 
 DB_REST_URL = get_config('INDRA_DB_REST_URL')
 

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -650,7 +650,8 @@ class FromSource(StatementFinder):
             verb_wrap = ' can affect '
             ps = super(FromSource, self).describe(limit=limit)
         else:
-            verb_wrap = ' can have the effect of %s on ' % self.query.stmt_type
+            verb_wrap = ' can %s ' % \
+                statement_base_verb(self.query.stmt_type.lower())
             ps = ''
         desc = "Overall, I found that " + self.query.subj.name + verb_wrap
         other_names = self.get_other_names(self.query.subj,
@@ -687,7 +688,8 @@ class ToTarget(StatementFinder):
             verb_wrap = ' can affect '
             ps = super(ToTarget, self).describe(limit=limit)
         else:
-            verb_wrap = ' can have the effect of %s on ' % self.query.stmt_type
+            verb_wrap = ' can %s ' % \
+                statement_base_verb(self.query.stmt_type.lower())
             ps = ''
 
         desc = "Overall, I found that"

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -23,9 +23,9 @@ from indra.assemblers.english.assembler import english_join, \
 logger = logging.getLogger('MSA')
 
 
-def _build_mod_map():
+def _build_verb_map():
     stmts = get_all_descendants(Statement)
-    mod_map = {}
+    verb_map = {}
     non_binary = ('hasactivity', 'activeform', 'selfmodification',
                   'autophosphorylation', 'transphosphorylation',
                   'event', 'unresolved', 'association', 'complex')
@@ -34,13 +34,13 @@ def _build_mod_map():
         if name.lower() in non_binary:
             continue
         base_verb = statement_base_verb(name.lower())
-        mod_map[base_verb] = name
+        verb_map[base_verb] = name
         present_verb = statement_present_verb(name.lower())
-        mod_map[present_verb] = name
-    return mod_map
+        verb_map[present_verb] = name
+    return verb_map
 
 
-mod_map = _build_mod_map()
+verb_map = _build_verb_map()
 
 
 DB_REST_URL = get_config('INDRA_DB_REST_URL')
@@ -93,8 +93,8 @@ class StatementQuery(object):
         self.agent_keys = [self.get_query_key(e) for e in agents]
 
         self.verb = verb
-        if verb in mod_map.keys():
-            self.stmt_type = mod_map[verb]
+        if verb in verb_map:
+            self.stmt_type = verb_map[verb]
         else:
             self.stmt_type = verb
 
@@ -646,7 +646,7 @@ class FromSource(StatementFinder):
 
     def describe(self, limit=10):
         if self.query.stmt_type is None:
-            verb_wrap = ' can interact with '
+            verb_wrap = ' can be affected by '
             ps = super(FromSource, self).describe(limit=limit)
         else:
             verb_wrap = ' can have the effect of %s on ' % self.query.stmt_type
@@ -683,7 +683,7 @@ class ToTarget(StatementFinder):
 
     def describe(self, limit=5):
         if self.query.stmt_type is None:
-            verb_wrap = ' can interact with '
+            verb_wrap = ' can affect '
             ps = super(ToTarget, self).describe(limit=limit)
         else:
             verb_wrap = ' can have the effect of %s on ' % self.query.stmt_type

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -17,7 +17,8 @@ from indra.sources import indra_db_rest as idbr
 
 from indra.assemblers.html import HtmlAssembler
 from indra.assemblers.graph import GraphAssembler
-from indra.assemblers.english.assembler import _join_list, statement_base_verb
+from indra.assemblers.english.assembler import english_join, \
+    statement_base_verb, statement_present_verb
 
 logger = logging.getLogger('MSA')
 
@@ -34,6 +35,8 @@ def _build_mod_map():
             continue
         base_verb = statement_base_verb(name.lower())
         mod_map[base_verb] = name
+        present_verb = statement_present_verb(name.lower())
+        mod_map[present_verb] = name
     return mod_map
 
 
@@ -532,7 +535,7 @@ class Neighborhood(StatementFinder):
         desc += "\nOverall, I found the following entities in the " \
                 "neighborhood of %s: " % self.query.agents[0].name
         other_names = self.get_other_names(self.query.agents[0])
-        desc += _join_list(other_names[:max_names])
+        desc += english_join(other_names[:max_names])
         desc += '.'
         return desc
 
@@ -602,7 +605,7 @@ class BinaryDirected(StatementFinder):
         if stmt_types:
             desc = "Overall, I found that %s can %s %s." % \
                    (self.query.subj.name,
-                    _join_list([statement_base_verb(v) for v in stmt_types]),
+                    english_join([statement_base_verb(v) for v in stmt_types]),
                     self.query.obj.name)
         else:
             desc = 'Overall, I found that %s does not affect %s.' % names
@@ -629,8 +632,8 @@ class BinaryUndirected(StatementFinder):
         if stmt_types:
             desc = "Overall, I found that %s and %s interact in the " \
                    "following ways: " % tuple(names)
-            desc += (_join_list([v if v not in overrides else overrides[v]
-                                 for v in stmt_types]) + '.')
+            desc += (english_join([v if v not in overrides else overrides[v]
+                                   for v in stmt_types]) + '.')
         else:
             desc = 'Overall, I found that %s and %s do not interact.' \
                    % tuple(names)
@@ -655,9 +658,9 @@ class FromSource(StatementFinder):
         if len(other_names) > limit:
             # We trim the trailing space of desc here before appending
             desc = desc[:-1] + ', for example, '
-            desc += _join_list(other_names[:limit]) + '.\n'
+            desc += english_join(other_names[:limit]) + '.\n'
         elif 0 < len(other_names) <= limit:
-            desc += _join_list(other_names) + '.\n'
+            desc += english_join(other_names) + '.\n'
         else:
             desc += 'nothing.\n'
 
@@ -691,9 +694,9 @@ class ToTarget(StatementFinder):
                                            other_role='subject')
         if len(other_names) > limit:
             desc += ', for example, '
-            desc += _join_list(other_names[:limit])
+            desc += english_join(other_names[:limit])
         elif 0 < len(other_names) <= limit:
-            desc += ' ' + _join_list(other_names)
+            desc += ' ' + english_join(other_names)
         else:
             desc += ' nothing'
         desc += verb_wrap
@@ -721,7 +724,7 @@ class ComplexOneSide(StatementFinder):
         desc = "Overall, I found that %s can be in a complex with: " % \
                self.query.agents[0].name
         other_names = self.get_other_names(self.query.agents[0])
-        desc += _join_list(other_names[:max_names])
+        desc += english_join(other_names[:max_names])
         return desc
 
     def _filter_stmts(self, stmts):
@@ -833,8 +836,8 @@ class _Commons(StatementFinder):
 
     def describe(self, *args, **kwargs):
         desc = "Overall, I found that %s have the following common %s: %s" \
-               % (_join_list([ag.name for ag in self.query.agents]),
-                  self._name, _join_list(self.get_common_entities()))
+               % (english_join([ag.name for ag in self.query.agents]),
+                  self._name, english_join(self.get_common_entities()))
         return desc
 
 

--- a/bioagents/tests/bionlg_test.py
+++ b/bioagents/tests/bionlg_test.py
@@ -40,7 +40,7 @@ class _NlgTestBase(_IntegrationTest):
         nl_list = output.get('nl')
         for i, sent in enumerate(nl_list):
             assert sent.string_value() == self.sentences[i],\
-                "Expected %s, but got %s." % (sent, self.sentences[i])
+                "Expected %s, but got %s." % (self.sentences[i], sent)
 
 
 class TestActiveFlag(_NlgTestBase):
@@ -51,7 +51,7 @@ class TestActiveFlag(_NlgTestBase):
 class TestBoundConditionAndResidues(_NlgTestBase):
     statements = [Phosphorylation(kras_bound, braf, position='373'),
                   Phosphorylation(braf, mapk3, residue='T', position='202')]
-    sentences = ["KRAS bound to GTP phosphorylates BRAF",
+    sentences = ["KRAS bound to GTP phosphorylates BRAF at position 373",
                  "BRAF phosphorylates MAPK3 on T202"]
 
 


### PR DESCRIPTION
This PR makes the following improvements:
- extends the set of verbs that can be used to constrain query statement types (e.g. increase amount)
- sort statement types by overall evidence when summarizing them in results
- make a couple of responses sound more natural