### PR TITLE
Separate query result summary from NL description in MSA

### DIFF
--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -590,7 +590,7 @@ class BinaryDirected(StatementFinder):
         return summary
 
     def describe(self, limit=None):
-        summary = self.get_summary()
+        summary = self.summarize()
         if summary['stmt_types']:
             desc = "Overall, I found that %s can %s %s." % \
                    (summary['query_subj'].name,
@@ -643,7 +643,7 @@ class FromSource(StatementFinder):
     def summarize(self):
         summary = {'stmt_type': self.query.stmt_type,
                    'query_subj': self.query.subj,
-                   'other_agents': self.get_other_agents(self.query.subj,
+                   'other_agents': self.get_other_agents([self.query.subj],
                                                          other_role='object')}
         return summary
 
@@ -690,7 +690,7 @@ class ToTarget(StatementFinder):
         summary = {
             'stmt_type': self.query.stmt_type,
             'query_obj': self.query.obj,
-            'other_agents': self.get_other_agents(self.query.obj,
+            'other_agents': self.get_other_agents([self.query.obj],
                                                   other_role='subject')
         }
         return summary
@@ -715,7 +715,7 @@ class ToTarget(StatementFinder):
         else:
             desc += ' nothing'
         desc += verb_wrap
-        desc += summary['query_agent'].name + '. '
+        desc += summary['query_obj'].name + '. '
 
         desc += ps
         return desc
@@ -746,7 +746,7 @@ class ComplexOneSide(StatementFinder):
         desc = "Overall, I found that %s can be in a complex with: " % \
                summary['query_agent']
         desc += english_join([a.name for a in
-                              summary['other_agents'][:max_names])
+                              summary['other_agents'][:max_names]])
         return desc
 
     def _filter_stmts(self, stmts):

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -659,8 +659,11 @@ class FromSource(StatementFinder):
         return StatementQuery(source, None, [], verb, ent_type, params)
 
     def summarize(self):
-        summary = {'stmt_type': statement_base_verb(
-                                    self.query.stmt_type.lower()),
+        if self.query.stmt_type:
+            stmt_type = statement_base_verb(self.query.stmt_type.lower())
+        else:
+            stmt_type = None
+        summary = {'stmt_type': stmt_type,
                    'query_subj': self.query.subj,
                    'other_agents': self.get_other_agents([self.query.subj],
                                                          other_role='object')}
@@ -706,8 +709,12 @@ class ToTarget(StatementFinder):
         return StatementQuery(None, target, [], verb, ent_type, params)
 
     def summarize(self):
+        if self.query.stmt_type:
+            stmt_type = statement_base_verb(self.query.stmt_type.lower())
+        else:
+            stmt_type = None
         summary = {
-            'stmt_type': statement_base_verb(self.query.stmt_type.lower()),
+            'stmt_type': stmt_type,
             'query_obj': self.query.obj,
             'other_agents': self.get_other_agents([self.query.obj],
                                                   other_role='subject')

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -641,7 +641,8 @@ class FromSource(StatementFinder):
         return StatementQuery(source, None, [], verb, ent_type, params)
 
     def summarize(self):
-        summary = {'stmt_type': self.query.stmt_type,
+        summary = {'stmt_type': statement_base_verb(
+                                    self.query.stmt_type.lower()),
                    'query_subj': self.query.subj,
                    'other_agents': self.get_other_agents([self.query.subj],
                                                          other_role='object')}
@@ -653,8 +654,7 @@ class FromSource(StatementFinder):
             verb_wrap = ' can affect '
             ps = super(FromSource, self).describe(limit=limit)
         else:
-            verb_wrap = ' can %s ' % \
-                statement_base_verb(summary['stmt_type'].lower())
+            verb_wrap = ' can %s ' % summary['stmt_type']
             ps = ''
         desc = "Overall, I found that " + summary['query_subj'].name + \
                verb_wrap
@@ -688,7 +688,7 @@ class ToTarget(StatementFinder):
 
     def summarize(self):
         summary = {
-            'stmt_type': self.query.stmt_type,
+            'stmt_type': statement_base_verb(self.query.stmt_type.lower()),
             'query_obj': self.query.obj,
             'other_agents': self.get_other_agents([self.query.obj],
                                                   other_role='subject')
@@ -701,8 +701,7 @@ class ToTarget(StatementFinder):
             verb_wrap = ' can affect '
             ps = super(ToTarget, self).describe(limit=limit)
         else:
-            verb_wrap = ' can %s ' % \
-                statement_base_verb(summary['stmt_type'].lower())
+            verb_wrap = ' can %s ' % summary['stmt_type']
             ps = ''
 
         desc = "Overall, I found that"

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -778,9 +778,10 @@ class ComplexOneSide(StatementFinder):
     def describe(self, max_names=20):
         summary = self.summarize()
         desc = "Overall, I found that %s can be in a complex with: " % \
-               summary['query_agent']
+               summary['query_agent'].name
         desc += english_join([a.name for a in
                               summary['other_agents'][:max_names]])
+        desc += '.'
         return desc
 
     def _filter_stmts(self, stmts):

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -547,6 +547,12 @@ class Activeforms(StatementFinder):
                            "Activeforms or PhosActiveforms.")
         return StatementQuery(None, None, [entity], 'ActiveForm', None, params)
 
+    def summarize(self):
+        # Note that the generic form of grouped ActiveForm statements is
+        # degenerate so we just choose the first few actual statements here
+        summary = {'summary_stmts': self.get_statements()[:5]}
+        return summary
+
 
 class PhosActiveforms(Activeforms):
     def __init__(self, *args, **kwargs):

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -486,31 +486,6 @@ class StatementFinder(object):
         msg = json.dumps(stmts_to_json(self.get_statements()), indent=1)
         return msg
 
-    def get_other_names(self, entity, other_role=None):
-        """Find all the resulting agents besides the one given.
-
-        It is assumed that the given entity was one of the inputs.
-
-        Parameters
-        ----------
-        entity : str or Agent.
-            Either an original entity string or Agent, or Agent name. This
-            method will find other entities that occur within the statements
-            besides this one.
-        other_role : 'subject', 'object', or None
-            The part of speech/role of the other names. Limits the results to
-            subjects, if 'subject', objects if 'object', or places no limit
-            if None. Default is None.
-        """
-        other_ags = self.get_other_agents([entity], other_role=other_role)
-        names = []
-        for ag in other_ags:
-            # We know the agents are ordered by name, so this is sufficient.
-            if names and ag.name == names[-1]:
-                continue
-            names.append(ag.name)
-        return names
-
     def filter_other_agent_type(self, stmts, ent_type, other_role=None):
         query_entities = set(self.query.entities.values())
         stmts_out = []

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -529,14 +529,16 @@ class Neighborhood(StatementFinder):
 
     def describe(self, max_names=20):
         summary = self.summarize()
-        desc = ('\nOverall, I found that %s interacts with ' %
-                summary['query_agent'].name)
-        if summary['other_agents']:
+        desc = ('Overall, I found that %s interacts with%s ' %
+                (summary['query_agent'].name,
+                 ', for instance,' if len(summary['other_agents']) > max_names
+                 else ''))
+        if summary['other_agents'][:max_names]:
             desc += english_join([a.name for a in
                                   summary['other_agents'][:max_names]])
         else:
             desc += 'nothing'
-        desc += '.'
+        desc += '. '
         desc += super(Neighborhood, self).describe(include_negative=False)
         return desc
 
@@ -777,7 +779,7 @@ class ComplexOneSide(StatementFinder):
 
     def describe(self, max_names=20):
         summary = self.summarize()
-        desc = "Overall, I found that %s can be in a complex with: " % \
+        desc = "Overall, I found that %s can be in a complex with " % \
                summary['query_agent'].name
         desc += english_join([a.name for a in
                               summary['other_agents'][:max_names]])

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -523,7 +523,8 @@ class Neighborhood(StatementFinder):
 
     def summarize(self):
         summary = {'query_agent': self.query.agents[0],
-                   'other_agents': self.get_other_agents(self.query.agents[0])}
+                   'other_agents':
+                       self.get_other_agents([self.query.agents[0]])}
         return summary
 
     def describe(self, max_names=20):
@@ -769,7 +770,8 @@ class ComplexOneSide(StatementFinder):
 
     def summarize(self):
         summary = {'query_agent': self.query.agents[0],
-                   'other_agents': self.get_other_agents(self.query.agents[0]),
+                   'other_agents':
+                       self.get_other_agents([self.query.agents[0]]),
                    'stmt_type': 'complex'}
         return summary
 

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -694,11 +694,11 @@ class FromSource(StatementFinder):
         if len(other_names) > limit:
             # We trim the trailing space of desc here before appending
             desc = desc[:-1] + ', for example, '
-            desc += english_join(other_names[:limit]) + '.\n'
+            desc += english_join(other_names[:limit]) + '. '
         elif 0 < len(other_names) <= limit:
-            desc += english_join(other_names) + '.\n'
+            desc += english_join(other_names) + '. '
         else:
-            desc += 'nothing.\n'
+            desc += 'nothing. '
 
         desc += ps
         return desc

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -538,7 +538,7 @@ def test_complex_one_side_entity_filter():
     summ = finder.summarize()
     assert 'PTEN' in {a.name for a in summ['other_agents']}
     desc = finder.describe()
-    assert re.match(r'Overall, I found that BRAF can be in a complex with: ' \
+    assert re.match(r'Overall, I found that BRAF can be in a complex with '
                     'PTEN, .* and DUSP4.', desc), desc
 
 
@@ -550,6 +550,12 @@ def test_neighbors_agent_filter():
     for stmt in stmts:
         ag_names = {ag.name for ag in stmt.agent_list() if ag is not None}
         assert ag_names & {'ERK', 'MEK'}
+
+    summ = finder.summarize()
+    assert 'KRAS' in {a.name for a in summ['other_agents']}, summ
+    desc = finder.describe()
+    assert re.match(r'Overall, I found that BRAF interacts with, '
+                    r'for instance, ERK, .* Here are the top.*', desc), desc
 
 
 @attr('nonpublic')

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -587,12 +587,20 @@ def test_to_target_agent_filter():
                     r'ZEB1. Here are the statements.*', desc), desc
 
 
-@attr('nonpublic', 'slow')
+@attr('nonpublic')
 def test_from_source_agent_filter():
-    finder = msa.FromSource(_erk(), filter_agents=[_mek(), _braf(), _erk()])
+    cdk12 = Agent('CDK12', db_refs={'HGNC': '24224'})
+    samhd1 = Agent('SAMHD1', db_refs={'HGNC': '15925'})
+    ezh2 = Agent('EZH2', db_refs={'HGNC': '3527'})
+    finder = msa.FromSource(cdk12, filter_agents=[samhd1, ezh2])
     stmts = finder.get_statements()
     assert len(stmts)
-    exp_ags = {'MEK', 'BRAF', 'KRAS', 'ERK'}
+    exp_ags = {'SAMHD1', 'EZH2'}
     for stmt in stmts:
         ag_names = {ag.name for ag in stmt.agent_list() if ag is not None}
         assert ag_names & exp_ags, ag_names - exp_ags
+    summ = finder.summarize()
+    assert 'SAMHD1' in {a.name for a in summ['other_agents']}, summ
+    desc = finder.describe()
+    assert re.match(r'Overall, I found that CDK12 can affect '
+                    r'SAMHD1 and EZH2. Here are the statements.*', desc), desc

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -604,3 +604,26 @@ def test_from_source_agent_filter():
     desc = finder.describe()
     assert re.match(r'Overall, I found that CDK12 can affect '
                     r'SAMHD1 and EZH2. Here are the statements.*', desc), desc
+
+
+@attr('nonpublic')
+def test_binary_summary_description():
+    cdk12 = Agent('CDK12', db_refs={'HGNC': '24224'})
+    ezh2 = Agent('EZH2', db_refs={'HGNC': '3527'})
+
+    # Directed
+    finder = msa.BinaryDirected(cdk12, ezh2)
+    summ = finder.summarize()
+    assert 'EZH2' == summ['query_obj'].name, summ
+    desc = finder.describe()
+    assert re.match(r'Overall, I found that CDK12 can phosphorylate and '
+                    r'activate EZH2.', desc), desc
+
+    # Undirected
+    finder = msa.BinaryUndirected(cdk12, ezh2)
+    summ = finder.summarize()
+    assert 'EZH2' == summ['query_agents'][1].name, summ
+    desc = finder.describe()
+    assert re.match(r'Overall, I found that CDK12 and EZH2 interact in the '
+                    r'following ways: phosphorylation and activation.',
+                    desc), desc

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -535,6 +535,12 @@ def test_complex_one_side_entity_filter():
     assert 'PTEN' in oa_names
     assert 'BRAF' not in oa_names
 
+    summ = finder.summarize()
+    assert 'PTEN' in {a.name for a in summ['other_agents']}
+    desc = finder.describe()
+    assert re.match(r'Overall, I found that BRAF can be in a complex with: ' \
+                    'PTEN, .* and DUSP4.', desc), desc
+
 
 @attr('nonpublic')
 def test_neighbors_agent_filter():

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -570,19 +570,25 @@ def test_upstreams_agent_filter():
         assert ag_names & exp_ags, ag_names - exp_ags - {'MEK', 'ERK'}
 
 
-@attr('nonpublic', 'slow')
+@attr('nonpublic')
 def test_to_target_agent_filter():
-    finder = msa.ToTarget(_erk(), filter_agents=[_mek(), _braf(), _kras()])
+    zeb1 = Agent('ZEB1', db_refs={'HGNC': '11642'})
+    finder = msa.ToTarget(zeb1, filter_agents=[_mek(), _braf(), _kras()])
     stmts = finder.get_statements()
     assert len(stmts)
     exp_ags = {'MEK', 'BRAF', 'KRAS'}
     for stmt in stmts:
         ag_names = {ag.name for ag in stmt.agent_list() if ag is not None}
         assert ag_names & exp_ags, ag_names - exp_ags - {'ERK'}
+    summ = finder.summarize()
+    assert 'KRAS' in {a.name for a in summ['other_agents']}, summ
+    desc = finder.describe()
+    assert re.match(r'Overall, I found that MEK and KRAS can affect '
+                    r'ZEB1. Here are the statements.*', desc), desc
 
 
 @attr('nonpublic', 'slow')
-def test_to_target_agent_filter():
+def test_from_source_agent_filter():
     finder = msa.FromSource(_erk(), filter_agents=[_mek(), _braf(), _erk()])
     stmts = finder.get_statements()
     assert len(stmts)

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -399,14 +399,12 @@ def test_get_finder_agents():
     finder = msa.find_mechanisms('to_target', ag, verb='phosphorylate')
     other_agents = finder.get_other_agents()
     assert all(isinstance(a, Agent) for a in other_agents)
+    # The other names should be sorted with PIM1 first (most evidence)
+    assert other_agents[0].name == 'PIM1'
 
     fixed_agents = finder.get_fixed_agents()
     assert 'object' in fixed_agents, fixed_agents
     assert fixed_agents['object'][0].name == 'SOCS1', fixed_agents['target']
-
-    # The other names should be sorted with PIM1 first (most evidence)
-    other_names = finder.get_other_names(ag)
-    assert other_names[0] == 'PIM1', other_names
 
 
 @attr('nonpublic')


### PR DESCRIPTION
This PR refactors the `describe` methods by introducing a `summarize` method that produces a structured dict containing the values needed to describe the results. This can be called separately by other code importing the MSA. The `describe` methods now themselves call `summarize` to get the relevant values (this is not strictly necessary but it makes the separation more clear).