### PR TITLE
Further refactoring to use CL-JSON

### DIFF
--- a/bioagents/biosense/biosense_module.py
+++ b/bioagents/biosense/biosense_module.py
@@ -2,6 +2,7 @@ import sys
 import logging
 import indra
 from indra.sources import trips
+from indra.statements import BioContext, RefContext
 from .biosense import BioSense
 from .biosense import InvalidAgentError, UnknownCategoryError, \
     SynonymsUnknownError
@@ -41,10 +42,31 @@ class BioSense_Module(Bioagent):
         # Then turn the graph into an EKB XML object, expanding around the
         # given ID
         ekb = EKB(graph, id_base)
+        ekb_str = ekb.to_string()
         # Now process the EKB using the TRIPS processor to extract Statements
-        tp = trips.process_xml(ekb.to_string())
+        tp = trips.process_xml(ekb_str)
+
+        # Look for a term representing a cell line
+        def get_cell_line(et):
+            cl_tag = et.find("TERM/[type='ONT::CELL-LINE']/text")
+            if cl_tag is not None:
+                cell_line = cl_tag.text
+                cell_line.replace('-', '')
+                # TODO: add grounding here if available
+                clc = RefContext(cell_line)
+                return clc
+            return None
+
         # If there are any statements then we can return the CL-JSON of those
         if tp.statements:
+            # Set cell line context if available
+            cell_line = get_cell_line(ekb)
+            if cell_line:
+                for stmt in tp.statements:
+                    ev = stmt.evidence[0]
+                    if not ev.context:
+                        ev.context = BioContext(cell_line=context)
+            # Now make the CL-JSON for the given statements
             js = self.make_cljson(tp.statements)
         # Otherwise, we try extracting an Agent and return that
         else:
@@ -56,7 +78,7 @@ class BioSense_Module(Bioagent):
                 agent = add_agent_type(agent)
                 js = self.make_cljson(agent)
             except Exception as e:
-                logger.info("Encountered an error while parsing: %s."
+                logger.info("Encountered an error while parsing: %s. "
                             "Returning empty list." % content.to_string())
                 logger.exception(e)
                 js = KQMLList()

--- a/bioagents/biosense/biosense_module.py
+++ b/bioagents/biosense/biosense_module.py
@@ -48,9 +48,9 @@ class BioSense_Module(Bioagent):
 
         # If there are any statements then we can return the CL-JSON of those
         if tp.statements:
-            context = get_cell_line(ekb)
-            if context:
-                set_cell_line_context(tp.statements, context)
+            cell_line_context = get_cell_line(ekb.ekb)
+            if cell_line_context:
+                set_cell_line_context(tp.statements, cell_line_context)
             # Now make the CL-JSON for the given statements
             js = self.make_cljson(tp.statements)
         # Otherwise, we try extracting an Agent and return that

--- a/bioagents/mra/mra.py
+++ b/bioagents/mra/mra.py
@@ -204,10 +204,9 @@ class MRA(object):
                                      new_model_id))
         return new_model_id, stmts_new_to_add
 
-    def remove_mechanism(self, mech_ekb, model_id):
+    def remove_mechanism(self, mech_js, model_id):
         """Return a new model with the given mechanism having been removed."""
-        tp = trips.process_xml(mech_ekb)
-        rem_stmts = tp.statements
+        rem_stmts = stmts_from_json(json.loads(mech_js))
         return self.remove_mechanism_from_stmts(rem_stmts, model_id)
 
     def remove_mechanism_from_stmts(self, rem_stmts, model_id):
@@ -356,13 +355,7 @@ class MRA(object):
 
     def set_user_goal(self, explain):
         # Get the event itself
-        tp = trips.process_xml(explain)
-        if tp is None:
-            return {'error': 'Failed to process EKB.'}
-        print(tp.statements)
-        if not tp.statements:
-            return
-        self.explain = tp.statements[0]
+        self.explain = explain
 
         # Look for a term representing a cell line
         def get_context(explain_xml):

--- a/bioagents/mra/mra.py
+++ b/bioagents/mra/mra.py
@@ -354,24 +354,12 @@ class MRA(object):
         return upstream_agents
 
     def set_user_goal(self, explain):
-        # Get the event itself
+        # Set the given statement as context
         self.explain = explain
-
-        # Look for a term representing a cell line
-        def get_context(explain_xml):
-            import xml.etree.ElementTree as ET
-            et = ET.fromstring(explain_xml)
-            cl_tag = et.find("TERM/[type='ONT::CELL-LINE']/text")
-            if cl_tag is not None:
-                cell_line = cl_tag.text
-                cell_line.replace('-', '')
-                return cell_line
-            return None
-        try:
-            self.context = get_context(explain)
-        except Exception as e:
-            logger.error('MRA could not set context from USER-GOAL')
-            logger.error(e)
+        # Set the cell line context if available
+        context = explain.evidence[0].context
+        if context and context.cell_line:
+            self.context = context.cell_line.name
 
     def replace_agent(self, agent_name, agent_replacement_names, model_id):
         """Replace an agent in a model with other agents.

--- a/bioagents/mra/mra.py
+++ b/bioagents/mra/mra.py
@@ -327,14 +327,14 @@ class MRA(object):
             logger.info('Missing activities found: %s' % acts)
             res['stmt_corrections'] = acts
 
-    def has_mechanism(self, mech_ekb, model_id):
+    def has_mechanism(self, mech_json, model_id):
         """Return True if the given model contains the given mechanism."""
-        tp = trips.process_xml(mech_ekb)
+        stmts = stmts_from_json(json.loads(mech_json))
         res = {}
-        if not tp.statements:
+        if not stmts:
             res['has_mechanism'] = False
             return res
-        query_st = tp.statements[0]
+        query_st = stmts[0]
         res['query'] = query_st
         model_stmts = self.models[model_id]
         for model_st in model_stmts:

--- a/bioagents/mra/mra_module.py
+++ b/bioagents/mra/mra_module.py
@@ -265,11 +265,12 @@ class MRA_Module(Bioagent):
 
     def respond_model_remove_mechanism(self, content):
         """Return response content to model-remove-mechanism request."""
-        ekb = content.gets('description')
         model_id = self._get_model_id(content)
+        descr = content.get('description')
+        js = json.dumps(self.converter.cl_to_json(descr))
         no_display = content.get('no-display')
         try:
-            res = self.mra.remove_mechanism(ekb, model_id)
+            res = self.mra.remove_mechanism(js, model_id)
         except Exception as e:
             raise InvalidModelDescriptionError(e)
         model_id = res.get('model_id')
@@ -347,8 +348,9 @@ class MRA_Module(Bioagent):
 
     def respond_user_goal(self, content):
         """Record user goal and return success if possible"""
-        explain = content.gets('explain')
-        self.mra.set_user_goal(explain)
+        explain = content.get('explain')
+        explain_stmt = self.get_statement(explain)
+        self.mra.set_user_goal(explain_stmt)
         # We reset the explanations here
         self.have_explanation = False
         reply = KQMLList('SUCCESS')

--- a/bioagents/mra/mra_module.py
+++ b/bioagents/mra/mra_module.py
@@ -247,7 +247,7 @@ class MRA_Module(Bioagent):
         descr = content.get('description')
         js = json.dumps(self.converter.cl_to_json(descr))
         try:
-            res = self.mra.expand_model_from_json(js, model_id)
+            res = self.mra.has_mechanism(js, model_id)
         except Exception as e:
             raise InvalidModelDescriptionError(e)
         # Start a SUCCESS message

--- a/bioagents/mra/mra_module.py
+++ b/bioagents/mra/mra_module.py
@@ -243,10 +243,11 @@ class MRA_Module(Bioagent):
 
     def respond_model_has_mechanism(self, content):
         """Return response content to model-has-mechanism request."""
-        ekb = content.gets('description')
         model_id = self._get_model_id(content)
+        descr = content.get('description')
+        js = json.dumps(self.converter.cl_to_json(descr))
         try:
-            res = self.mra.has_mechanism(ekb, model_id)
+            res = self.mra.expand_model_from_json(js, model_id)
         except Exception as e:
             raise InvalidModelDescriptionError(e)
         # Start a SUCCESS message

--- a/bioagents/mra/mra_module.py
+++ b/bioagents/mra/mra_module.py
@@ -350,6 +350,8 @@ class MRA_Module(Bioagent):
         """Record user goal and return success if possible"""
         explain = content.get('explain')
         explain_stmt = self.get_statement(explain)
+        if explain_stmt and isinstance(explain_stmt, list):
+            explain_stmt = explain_stmt[0]
         self.mra.set_user_goal(explain_stmt)
         # We reset the explanations here
         self.have_explanation = False

--- a/bioagents/tests/biosense_test.py
+++ b/bioagents/tests/biosense_test.py
@@ -57,7 +57,8 @@ class TestGetIndraRepresentationStatement(_IntegrationTest):
         super().__init__(BioSense_Module)
 
     def create_message(self):
-        content = KQMLList.from_string(_load_kqml('braf_phos_mek_site_pos.kqml'))
+        content = KQMLList.from_string(
+            _load_kqml('braf_phos_mek_site_pos.kqml'))
         return get_request(content), content
 
     def check_response_to_message(self, output):

--- a/bioagents/tests/biosense_test.py
+++ b/bioagents/tests/biosense_test.py
@@ -174,6 +174,7 @@ def test_respond_choose_sense():
     assert agents_clj
     agent = Bioagent.get_agent(agents_clj)
     assert agent.name == 'MAP2K1'
+    assert agent.db_refs['HGNC'] == '6840'
 
 
 def test_respond_choose_nonsense():
@@ -241,6 +242,8 @@ def test_respond_choose_sense_what_member():
     a2 = Bioagent.get_agent(m2)
     assert a1.name == 'MAP2K1'
     assert a2.name == 'MAP2K2'
+    assert a1.db_refs['HGNC'] == '6840'
+    assert a2.db_refs['UP'] == 'P36507'
 
 
 def test_respond_get_synonyms():

--- a/bioagents/tests/mra_test.py
+++ b/bioagents/tests/mra_test.py
@@ -64,10 +64,10 @@ def test_get_upstream():
 
 def test_has_mechanism():
     m = MRA()
-    ekb = ekb_from_text('BRAF binds MEK')
-    m.build_model_from_ekb(ekb)
-    has_mechanism = m.has_mechanism(ekb, 1)
-    assert(has_mechanism)
+    stmtsj = json.dumps(stmts_json_from_text('BRAF binds MEK'))
+    m.build_model_from_json(stmtsj)
+    has_mechanism = m.has_mechanism(stmtsj, 1)
+    assert has_mechanism
 
 
 def test_transformations():

--- a/bioagents/tests/mra_test.py
+++ b/bioagents/tests/mra_test.py
@@ -559,8 +559,7 @@ class TestModelBuildExpandRemove(_IntegrationTest):
     def create_remove(self):
         content = KQMLList('MODEL-REMOVE-MECHANISM')
         content.set('model-id', '2')
-        content.sets('description',
-                     ekb_kstring_from_text('KRAS activates BRAF'))
+        content.set('description', stmts_clj_from_text('KRAS activates BRAF'))
         msg = get_request(content)
         return msg, content
 
@@ -578,8 +577,7 @@ class TestModelBuildExpandRemove(_IntegrationTest):
     def create_remove2(self):
         content = KQMLList('MODEL-REMOVE-MECHANISM')
         content.set('model-id', '3')
-        content.sets('description',
-                     ekb_kstring_from_text('NRAS activates BRAF'))
+        content.set('description', stmts_clj_from_text('NRAS activates BRAF'))
         msg = get_request(content)
         return msg, content
 
@@ -607,7 +605,6 @@ class TestModelBuildExpandRemove(_IntegrationTest):
         assert len(model) == 1
 
 
-
 class TestModelRemoveWrong(_IntegrationTest):
     def __init__(self, *args):
         super().__init__(MRA_Module)
@@ -626,7 +623,7 @@ class TestModelRemoveWrong(_IntegrationTest):
     def create_remove(self):
         content = KQMLList('MODEL-REMOVE-MECHANISM')
         content.set('model-id', '1')
-        content.sets('description', ekb_kstring_from_text('Unphosphorylated ERK'))
+        content.set('description', stmts_clj_from_text('Unphosphorylated ERK'))
         msg = get_request(content)
         return msg, content
 
@@ -653,7 +650,7 @@ class TestModelHasMechanism(_IntegrationTest):
     def create_hasmech1(self):
         content = KQMLList('MODEL-HAS-MECHANISM')
         content.set('model-id', '1')
-        content.sets('description', ekb_kstring_from_text('KRAS activates BRAF'))
+        content.sets('description', stmts_clj_from_text('KRAS activates BRAF'))
         msg = get_request(content)
         return msg, content
 
@@ -664,7 +661,7 @@ class TestModelHasMechanism(_IntegrationTest):
     def create_hasmech2(self):
         content = KQMLList('MODEL-HAS-MECHANISM')
         content.set('model-id', '1')
-        content.sets('description', ekb_kstring_from_text('NRAS activates BRAF'))
+        content.sets('description', stmts_clj_from_text('NRAS activates BRAF'))
         msg = get_request(content)
         return msg, content
 
@@ -679,7 +676,9 @@ class TestUserGoal(_IntegrationTest):
 
     def create_message(self):
         txt = 'Selumetinib decreases FOS in BT20 cells'
-        explain = ekb_kstring_from_text(txt)
+        explain = stmts_clj_from_text(txt)
+        explain_stmt = self.bioagent.get_statement(explain)[0]
+        assert explain_stmt.evidence[0].context, explain_stmt.evidence[0]
         content = KQMLList('USER-GOAL')
         content.set('explain', explain)
         msg = get_request(content)

--- a/bioagents/tests/util.py
+++ b/bioagents/tests/util.py
@@ -42,6 +42,7 @@ def agent_clj_from_text(text):
 def stmts_from_text(text):
     """Return a list of INDRA Statements from text."""
     ekb_xml = read_or_load(text)
+    print(ekb_xml)
     tp = trips.process_xml(ekb_xml)
     return tp.statements
 

--- a/bioagents/tests/util.py
+++ b/bioagents/tests/util.py
@@ -44,7 +44,6 @@ def agent_clj_from_text(text):
 def stmts_from_text(text):
     """Return a list of INDRA Statements from text."""
     ekb_xml = read_or_load(text)
-    print(ekb_xml)
     tp = trips.process_xml(ekb_xml)
     context = get_cell_line(ET.fromstring(ekb_xml))
     if context:

--- a/bioagents/tests/util.py
+++ b/bioagents/tests/util.py
@@ -6,6 +6,8 @@ from kqml import KQMLString, KQMLPerformative
 from indra.sources import trips
 from indra.statements import stmts_to_json, Agent
 from bioagents import Bioagent
+from bioagents.biosense.biosense_module import get_cell_line, \
+    set_cell_line_context
 
 
 def ekb_from_text(text):
@@ -44,6 +46,9 @@ def stmts_from_text(text):
     ekb_xml = read_or_load(text)
     print(ekb_xml)
     tp = trips.process_xml(ekb_xml)
+    context = get_cell_line(ET.fromstring(ekb_xml))
+    if context:
+        set_cell_line_context(tp.statements, context)
     return tp.statements
 
 


### PR DESCRIPTION
This PR refactors further MRA capabilities to use CL-JSON as input (HAS-MECHANISM, REMOVE-MECHANISM and SET-USER-GOAL). It also adds tests to check that Agents returned from various capabilities are grounded.