### PR TITLE
Refactor all MRA outputs to use CL-JSON

### DIFF
--- a/bioagents/__init__.py
+++ b/bioagents/__init__.py
@@ -66,7 +66,9 @@ class Bioagent(KQMLModule):
     def get_statement(cls, cl_statement):
         """Get an INDRA Statement from cl-json"""
         stmt_json = cls.converter.cl_to_json(cl_statement)
-        if isinstance(stmt_json, list):
+        if not stmt_json:
+            return None
+        elif isinstance(stmt_json, list):
             return stmts_from_json(stmt_json)
         else:
             return Statement._from_json(stmt_json)

--- a/bioagents/mra/mra_module.py
+++ b/bioagents/mra/mra_module.py
@@ -100,7 +100,7 @@ class MRA_Module(Bioagent):
         if model and (descr_format == 'ekb' or not descr_format):
             self.send_background_support(model)
         model_msg = encode_indra_stmts(model)
-        msg.sets('model', model_msg)
+        msg.set('model', model_msg)
         # Add the diagrams
         diagrams = res.get('diagrams')
         if not no_display:
@@ -162,7 +162,7 @@ class MRA_Module(Bioagent):
         # Add the INDRA model json
         model = res.get('model')
         model_msg = encode_indra_stmts(model)
-        msg.sets('model', model_msg)
+        msg.set('model', model_msg)
         # Add the INDRA model new json
         model_new = res.get('model_new')
 
@@ -183,7 +183,7 @@ class MRA_Module(Bioagent):
             self.send_background_support(model_new)
         if model_new:
             model_new_msg = encode_indra_stmts(model_new)
-            msg.sets('model-new', model_new_msg)
+            msg.set('model-new', model_new_msg)
         # Add the diagram
         if not no_display:
             diagrams = res.get('diagrams')
@@ -218,14 +218,14 @@ class MRA_Module(Bioagent):
             self.send_clean_model()
 
         model_msg = encode_indra_stmts(model)
-        msg.sets('model', model_msg)
+        msg.set('model', model_msg)
         # Get the action and add it to the message
         action = res.get('action')
         actionl = KQMLList()
         # Here we handle no action as effectively an empty remove action
         if action['action'] in ('no_op', 'remove_stmts'):
             actionl.append('remove_stmts')
-            actionl.sets(
+            actionl.set(
                 'statements',
                 encode_indra_stmts(action['statements'])
                 )
@@ -260,7 +260,7 @@ class MRA_Module(Bioagent):
         query = res.get('query')
         if query:
             query_msg = encode_indra_stmts([query])
-            msg.sets('query', query_msg)
+            msg.set('query', query_msg)
         return msg
 
     def respond_model_remove_mechanism(self, content):
@@ -283,7 +283,7 @@ class MRA_Module(Bioagent):
         # Add the INDRA model json
         model = res.get('model')
         model_msg = encode_indra_stmts(model)
-        msg.sets('model', model_msg)
+        msg.set('model', model_msg)
 
         # Handle empty model
         if not model:
@@ -296,7 +296,7 @@ class MRA_Module(Bioagent):
             return msg
         else:
             actionl = KQMLList('remove_stmts')
-            actionl.sets('statements', encode_indra_stmts(removed))
+            actionl.set('statements', encode_indra_stmts(removed))
             msg.set('action', actionl)
 
         # Add the diagram
@@ -341,7 +341,7 @@ class MRA_Module(Bioagent):
         if model is not None:
             model_msg = encode_indra_stmts(model)
             reply = KQMLList('SUCCESS')
-            reply.sets('model', model_msg)
+            reply.set('model', model_msg)
         else:
             reply = self.make_failure('MISSING_MODEL')
         return reply
@@ -525,9 +525,8 @@ def encode_pysb_model(pysb_model):
 
 
 def encode_indra_stmts(stmts):
-    stmts_json = stmts_to_json(stmts)
-    json_str = json.dumps(stmts_json)
-    return json_str
+    stmts_clj = Bioagent.make_cljson(stmts)
+    return stmts_clj
 
 
 def get_ambiguities_msg(ambiguities):

--- a/bioagents/tests/mra_test.py
+++ b/bioagents/tests/mra_test.py
@@ -485,8 +485,8 @@ class TestGetModelJson(_IntegrationTest):
     def check_response_to_build(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '1'
-        model = json.loads(output.gets('model'))
-        assert len(model) == 1
+        stmts = self.bioagent.get_statement(output.get('model'))
+        assert len(stmts) == 1
 
     def create_get_json(self):
         content = KQMLList('MODEL-GET-JSON')
@@ -496,11 +496,10 @@ class TestGetModelJson(_IntegrationTest):
 
     def check_response_to_get_json(self, output):
         assert output.head() == 'SUCCESS'
-        model_json = output.gets('model')
-        assert model_json
-        jd = json.loads(model_json)
-        assert len(jd) == 1
-        assert jd[0]['type'] == 'Activation'
+        model_clj = output.get('model')
+        assert model_clj
+        stmts = self.bioagent.get_statement(model_clj)
+        assert isinstance(stmts[0], sts.Activation)
 
 
 class TestGetModelJsonNoID(_IntegrationTest):
@@ -515,7 +514,7 @@ class TestGetModelJsonNoID(_IntegrationTest):
     def check_response_to_build(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '1'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
 
     def create_get_json(self):
@@ -525,11 +524,11 @@ class TestGetModelJsonNoID(_IntegrationTest):
 
     def check_response_to_get_json(self, output):
         assert output.head() == 'SUCCESS'
-        model_json = output.gets('model')
-        assert model_json
-        jd = json.loads(model_json)
-        assert len(jd) == 1
-        assert jd[0]['type'] == 'Activation'
+        model_clj = output.get('model')
+        assert model_clj
+        stmts = self.bioagent.get_statement(model_clj)
+        assert len(stmts) == 1
+        assert isinstance(stmts[0], sts.Activation)
 
 
 class TestModelBuildExpandRemove(_IntegrationTest):
@@ -544,7 +543,7 @@ class TestModelBuildExpandRemove(_IntegrationTest):
     def check_response_to_build(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '1'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
 
     def create_expand(self):
@@ -553,7 +552,7 @@ class TestModelBuildExpandRemove(_IntegrationTest):
     def check_response_to_expand(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '2'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 2
 
     def create_remove(self):
@@ -566,12 +565,11 @@ class TestModelBuildExpandRemove(_IntegrationTest):
     def check_response_to_remove(self, output):
         assert output.head() == 'SUCCESS', output
         assert output.get('model-id') == '3'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
-        action  = output.get('action')
+        action = output.get('action')
         assert action.head() == 'remove_stmts'
-        rem_stmts_str = action.gets('statements')
-        rem_stmts = sts.stmts_from_json(json.loads(rem_stmts_str))
+        rem_stmts = self.bioagent.get_statement(action.get('statements'))
         assert len(rem_stmts) == 1
 
     def create_remove2(self):
@@ -584,12 +582,11 @@ class TestModelBuildExpandRemove(_IntegrationTest):
     def check_response_to_remove2(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '4'
-        model = json.loads(output.gets('model'))
-        assert len(model) == 0
-        action  = output.get('action')
+        model = self.bioagent.get_statement(output.get('model'))
+        assert not model
+        action = output.get('action')
         assert action.head() == 'remove_stmts'
-        rem_stmts_str = action.gets('statements')
-        rem_stmts = sts.stmts_from_json(json.loads(rem_stmts_str))
+        rem_stmts = self.bioagent.get_statement(action.get('statements'))
         assert len(rem_stmts) == 1
 
     def create_undo(self):
@@ -601,7 +598,7 @@ class TestModelBuildExpandRemove(_IntegrationTest):
     def check_response_to_undo(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '4'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
 
 
@@ -617,7 +614,7 @@ class TestModelRemoveWrong(_IntegrationTest):
     def check_response_to_build(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '1'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
 
     def create_remove(self):
@@ -644,7 +641,7 @@ class TestModelHasMechanism(_IntegrationTest):
     def check_response_to_build(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '1'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
 
     def create_hasmech1(self):
@@ -705,7 +702,7 @@ class TestModelMeetsGoal(_IntegrationTest):
     def check_response_to_build(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '1'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
 
     def create_expand(self):
@@ -736,7 +733,7 @@ class TestModelMeetsGoalBuildOnly(_IntegrationTest):
     def check_response_to_build(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '1'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
         has_explanation = output.gets('has_explanation')
         assert has_explanation == 'TRUE', has_explanation
@@ -758,7 +755,7 @@ class TestModelGapSuggest(_IntegrationTest):
     def check_response_to_build(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '1'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
 
     def create_expand(self):
@@ -768,7 +765,7 @@ class TestModelGapSuggest(_IntegrationTest):
     def check_response_to_expand(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '2'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 2
 
 
@@ -784,7 +781,7 @@ class TestDegradeSbgn(_IntegrationTest):
     def check_response_to_build(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '1'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
 
     def create_expand(self):
@@ -793,7 +790,7 @@ class TestDegradeSbgn(_IntegrationTest):
     def check_response_to_expand(self, output):
         assert output.head() == 'SUCCESS'
         assert output.get('model-id') == '2'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 2
 
 
@@ -809,7 +806,7 @@ class TestModelRefinement(_IntegrationTest):
     def check_response_to_build(self, output):
         assert output.head() == 'SUCCESS', output
         assert output.get('model-id') == '1'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
 
     def create_refine(self):
@@ -818,9 +815,9 @@ class TestModelRefinement(_IntegrationTest):
     def check_response_to_refine(self, output):
         assert output.head() == 'SUCCESS', output
         assert output.get('model-id') == '2'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
-        model_new = json.loads(output.gets('model-new'))
+        model_new = self.bioagent.get_statement(output.get('model-new'))
         assert len(model_new) == 1
 
     def create_refine2(self):
@@ -829,9 +826,9 @@ class TestModelRefinement(_IntegrationTest):
     def check_response_to_refine2(self, output):
         assert output.head() == 'SUCCESS', output
         assert output.get('model-id') == '3'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
-        assert output.gets('model-new') is None
+        assert not output.get('model-new')
 
     def create_refine3(self):
         return _get_expand_model_request('RAS activates RAF', '3')
@@ -839,9 +836,9 @@ class TestModelRefinement(_IntegrationTest):
     def check_response_to_refine3(self, output):
         assert output.head() == 'SUCCESS', output
         assert output.get('model-id') == '4'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
-        assert output.gets('model-new') is None
+        assert not output.get('model-new')
 
     def create_refine4(self):
         return _get_expand_model_request(
@@ -850,9 +847,9 @@ class TestModelRefinement(_IntegrationTest):
     def check_response_to_refine4(self, output):
         assert output.head() == 'SUCCESS', output
         assert output.get('model-id') == '5'
-        model = json.loads(output.gets('model'))
+        model = self.bioagent.get_statement(output.get('model'))
         assert len(model) == 1
-        model_new = json.loads(output.gets('model-new'))
+        model_new = self.bioagent.get_statement(output.get('model-new'))
         assert len(model_new) == 1
 
 '''


### PR DESCRIPTION
This PR changes all the Statement JSON strings embedded in MRA responses to be Statement CL-JSON KQML objects and updates all tests accordingly.