### PR TITLE
Handle complexes in EKB conversion and make MRA input fail if not a list

### DIFF
--- a/bioagents/ekb/ekb.py
+++ b/bioagents/ekb/ekb.py
@@ -197,9 +197,13 @@ class EKB(object):
         name_node = self.graph.get_matching_node(term_id, link='name')
         if not name_node:
             name_node = self.graph.get_matching_node(term_id, link='W')
-        name_val = self.graph.node[name_node]['label']
-        if name_val.startswith('W::'):
-            name_val = name_val[3:]
+
+        if name_node:
+            name_val = self.graph.node[name_node]['label']
+            if name_val.startswith('W::'):
+                name_val = name_val[3:]
+        else:
+            name_val = ''
         return name_val
 
     def term_to_ekb(self, term_id):

--- a/bioagents/ekb/ekb.py
+++ b/bioagents/ekb/ekb.py
@@ -53,7 +53,8 @@ class EKB(object):
             # TODO: This appears to be where we now get a failure. For some
             #  reason the ID being searched for is not being found, although it
             #  did exist in the original graph. Not sure if this actually has
-            #  to do with skipping the name (see earlier commit).
+            #  to do with skipping the name (see earlier commit). The id is
+            #  V61411.
             agent = tp._get_agent_by_id(self.root_term, None)
 
             # Set the TRIPS ID in db_refs

--- a/bioagents/ekb/ekb.py
+++ b/bioagents/ekb/ekb.py
@@ -50,11 +50,6 @@ class EKB(object):
             res = tp.statements
         # Otherwise, we try extracting an Agent and return that
         else:
-            # TODO: This appears to be where we now get a failure. For some
-            #  reason the ID being searched for is not being found, although it
-            #  did exist in the original graph. Not sure if this actually has
-            #  to do with skipping the name (see earlier commit). The id is
-            #  V61411.
             agent = tp._get_agent_by_id(self.root_term, None)
 
             # Set the TRIPS ID in db_refs

--- a/bioagents/ekb/ekb.py
+++ b/bioagents/ekb/ekb.py
@@ -223,10 +223,25 @@ class EKB(object):
 
         self.type = node['type']
 
+        if node['type'].upper() == 'ONT::MACROMOLECULAR-COMPLEX':
+            c1 = self.graph.get_matching_node(term_id, link='m-sequence')
+            c2 = self.graph.get_matching_node(term_id, link='m-sequence1')
+            components = etree.Element('components')
+            if c1:
+                self.term_to_ekb(c1)
+                c1tag = etree.Element('component', id=c1)
+                components.append(c1tag)
+            if c2:
+                self.term_to_ekb(c2)
+                c2tag = etree.Element('component', id=c2)
+                components.append(c2tag)
+            term.append(components)
+            self.ekb.append(term)
+            return
         # Handle the case of the signaling pathways.
         # Note: It turns out this will be wiped out by TRIPS further down the
         # line.
-        if node['type'].upper() == 'ONT::SIGNALING-PATHWAY':
+        elif node['type'].upper() == 'ONT::SIGNALING-PATHWAY':
             path_subject_id = self.graph.get_matching_node(term_id,
                                                            link='assoc-with')
             path_subject_name = self.get_term_name(path_subject_id)

--- a/bioagents/ekb/ekb.py
+++ b/bioagents/ekb/ekb.py
@@ -50,6 +50,10 @@ class EKB(object):
             res = tp.statements
         # Otherwise, we try extracting an Agent and return that
         else:
+            # TODO: This appears to be where we now get a failure. For some
+            #  reason the ID being searched for is not being found, although it
+            #  did exist in the original graph. Not sure if this actually has
+            #  to do with skipping the name (see earlier commit).
             agent = tp._get_agent_by_id(self.root_term, None)
 
             # Set the TRIPS ID in db_refs

--- a/bioagents/mra/mra_module.py
+++ b/bioagents/mra/mra_module.py
@@ -75,7 +75,12 @@ class MRA_Module(Bioagent):
         no_display = content.get('no-display')
         if not descr_format:
             descr = content.get('description')
-            js = json.dumps(self.converter.cl_to_json(descr))
+            js_data = self.converter.cl_to_json(descr)
+            if isinstance(js_data, dict):
+                logger.error('JSON data should be a list not a dict.')
+                raise InvalidModelDescriptionError("Model description should "
+                                                   "be a list of events.")
+            js = json.dumps(js_data)
             res = self.mra.build_model_from_json(js)
         elif descr_format == 'ekb':
             descr = content.gets('description')

--- a/bioagents/tests/biosense_test.py
+++ b/bioagents/tests/biosense_test.py
@@ -191,15 +191,6 @@ class TestGetIndraRepComplextEntities(_GetIndraRepTemplate):
         assert agents['EGFR'].bound_conditions[0].is_bound is True
 
 
-class TestGGetIndraRepDephosphorylation(_GetIndraRepTemplate):
-    kqml_file = 'dephosphorylation.kqml'
-
-    def check_result(self, res):
-        stmts = self.bioagent.get_statement(res)
-        assert len(stmts) == 1
-        assert isinstance(stmts[0], Dephosphorylation), stmts
-
-
 @unittest.skip('Cell line extraction not working yet')
 class TestGetIndraRepCellLineContext(_GetIndraRepTemplate):
     kqml_file = 'cell_line_context.kqml'

--- a/bioagents/tests/biosense_test.py
+++ b/bioagents/tests/biosense_test.py
@@ -181,6 +181,14 @@ class TestGetIndraRepComplextEntities(_GetIndraRepTemplate):
         stmts = self.bioagent.get_statement(res)
         assert len(stmts) == 1
         assert isinstance(stmts[0], Complex), stmts
+        stmt = stmts[0]
+        assert len(stmt.members) == 2
+        agents = {m.name: m for m in stmt.members}
+        assert 'EGFR' in agents
+        assert 'GRB2' in agents
+        assert agents['EGFR'].bound_conditions
+        assert agents['EGFR'].bound_conditions[0].agent.name == 'EGFR'
+        assert agents['EGFR'].bound_conditions[0].is_bound is True
 
 
 class TestGGetIndraRepDephosphorylation(_GetIndraRepTemplate):

--- a/bioagents/tests/biosense_test.py
+++ b/bioagents/tests/biosense_test.py
@@ -181,6 +181,15 @@ class TestGetIndraRepComplextEntities(_GetIndraRepTemplate):
         return
 
 
+class TestGGetIndraRepDephosphorylation(_GetIndraRepTemplate):
+    kqml_file = 'dephosphorylation.kqml'
+
+    def check_result(self, res):
+        stmts = self.bioagent.get_statement(res)
+        assert len(stmts) == 1
+        assert isinstance(stmts[0], Dephosphorylation), stmts
+
+
 @unittest.skip('Cell line extraction not working yet')
 class TestGetIndraRepCellLineContext(_GetIndraRepTemplate):
     kqml_file = 'cell_line_context.kqml'

--- a/bioagents/tests/biosense_test.py
+++ b/bioagents/tests/biosense_test.py
@@ -165,13 +165,20 @@ class TestGetIndraRepPathwayImmuneSystem(_GetIndraRepTemplate):
         assert agent.db_refs['TRIPS'].startswith('ONT::'), agent.db_refs
 
 
-class TestGGetIndraRepDephosphorylation(_GetIndraRepTemplate):
+class TestGetIndraRepDephosphorylation(_GetIndraRepTemplate):
     kqml_file = 'dephosphorylation.kqml'
 
     def check_result(self, res):
         stmts = self.bioagent.get_statement(res)
         assert len(stmts) == 1
         assert isinstance(stmts[0], Dephosphorylation), stmts
+
+
+class TestGetIndraRepComplextEntities(_GetIndraRepTemplate):
+    kqml_file = 'complex_entities.kqml'
+
+    def check_result(self, res):
+        return
 
 
 @unittest.skip('Cell line extraction not working yet')

--- a/bioagents/tests/biosense_test.py
+++ b/bioagents/tests/biosense_test.py
@@ -2,7 +2,7 @@ import unittest
 from nose.tools import raises
 from kqml import KQMLList
 from indra.statements import Phosphorylation, Agent, Statement, \
-    Dephosphorylation
+    Dephosphorylation, Complex
 from .integration import _IntegrationTest
 from .test_ekb import _load_kqml
 from bioagents import Bioagent
@@ -178,7 +178,9 @@ class TestGetIndraRepComplextEntities(_GetIndraRepTemplate):
     kqml_file = 'complex_entities.kqml'
 
     def check_result(self, res):
-        return
+        stmts = self.bioagent.get_statement(res)
+        assert len(stmts) == 1
+        assert isinstance(stmts[0], Complex), stmts
 
 
 class TestGGetIndraRepDephosphorylation(_GetIndraRepTemplate):

--- a/bioagents/tests/kqml/complex_entities.kqml
+++ b/bioagents/tests/kqml/complex_entities.kqml
@@ -1,0 +1,211 @@
+(GET-INDRA-REPRESENTATION :IDS (ONT::V61411) :CONTEXT
+                              ((ONT::TERM ONT::V61325 :INSTANCE-OF ONT::GENE-PROTEIN :DRUM
+                                ((:DRUM
+                                  (TERM :ID HGNC::|3236| :NAME "epidermal growth factor receptor" :SCORE 0.85542
+                                   :MATCHES ((MATCH :SCORE 0.85542 :MATCHED "EGFR" :STATUS "Approved Symbol" :EXACT 1))
+                                   :DBXREFS (UP::P00533) :ONT-TYPES (ONT::GENE))
+                                  (TERM :ID NCIT::C51744 :NAME "EGFR" :SCORE 0.85542 :MATCHES
+                                   ((MATCH :SCORE 0.85542 :MATCHED "EGFR" :STATUS "name" :EXACT 1)) :MAPPINGS
+                                   ((MAP :THROUGH
+                                         (CONCEPT NCIT::C16612
+                                          (SENSE (MORPH (POS N) (WORD GENE))
+                                           (PROVENANCE (NAME NCIT)
+                                            (FILENAME
+
+"/Users/mark/Projects/CLiC/cwc-integ/trips/bob/src/config/lisp/../../../src/TextTagger/drum-dsl/NCIT/01661.lisp"))))
+                                         :TO ONT::GENE))
+                                   :ONT-TYPES (ONT::GENE))
+                                  (TERM :ID UP::P0CY46 :NAME "Epidermal growth factor receptor" :SCORE 0.85368 :MATCHES
+                                   ((MATCH :SCORE 0.85368 :MATCHED "egfr" :STATUS "RecName: Short" :ALL-CAPS-NO-CAPS
+                                     1))
+                                   :DBXREFS (XFAM::PF00757 XFAM::PF14843 XFAM::PF07714 XFAM::PF01030) :ONT-TYPES
+                                   (ONT::PROTEIN))
+                                  (TERM :ID UP::P04412 :NAME "Epidermal growth factor receptor" :SCORE 0.85368 :MATCHES
+                                   ((MATCH :SCORE 0.85368 :MATCHED "egfr" :STATUS "RecName: Short" :ALL-CAPS-NO-CAPS
+                                     1))
+                                   :DBXREFS (XFAM::PF00757 XFAM::PF14843 XFAM::PF07714 XFAM::PF01030) :ONT-TYPES
+                                   (ONT::PROTEIN))
+                                  (TERM :ID GO::|0005006| :NAME "epidermal growth factor-activated receptor activity"
+                                   :SCORE 0.71084 :MATCHES
+                                   ((MATCH :SCORE 0.71084 :MATCHED "EGFR" :STATUS "EXACT synonym" :EXACT 1)) :ONT-TYPES
+                                   (ONT::PROTEIN))
+                                  (TERM :ID NCIT::C17068 :NAME "epidermal growth factor receptor" :SCORE 0.71084
+                                   :MATCHES ((MATCH :SCORE 0.71084 :MATCHED "EGFR" :STATUS "synonym" :EXACT 1))
+                                   :MAPPINGS
+                                   ((MAP :THROUGH
+                                         (CONCEPT NCIT::C17021
+                                          (SENSE (MORPH (POS N) (WORD PROTEIN))
+                                           (PROVENANCE (NAME NCIT)
+                                            (FILENAME
+
+"/Users/mark/Projects/CLiC/cwc-integ/trips/bob/src/config/lisp/../../../src/TextTagger/drum-dsl/NCIT/01702.lisp"))))
+                                         :TO ONT::PROTEIN))
+                                   :ONT-TYPES (ONT::PROTEIN))
+                                  (TERM :ID NCIT::C18436 :NAME "soluble ERBB-1 protein" :SCORE 0.71084 :MATCHES
+                                   ((MATCH :SCORE 0.71084 :MATCHED "EGFR" :STATUS "synonym" :EXACT 1)) :MAPPINGS
+                                   ((MAP :THROUGH
+                                         (CONCEPT NCIT::C17021
+                                          (SENSE (MORPH (POS N) (WORD PROTEIN))
+                                           (PROVENANCE (NAME NCIT)
+                                            (FILENAME
+
+"/Users/mark/Projects/CLiC/cwc-integ/trips/bob/src/config/lisp/../../../src/TextTagger/drum-dsl/NCIT/01702.lisp"))))
+                                         :TO ONT::PROTEIN))
+                                   :ONT-TYPES (ONT::PROTEIN))))
+                                :NAME W::EGFR :DBID "HGNC:3236" :DBNAME "epidermal growth factor receptor" :DB-TERM-ID
+                                "HGNC:3236" :DB-TERM-ID "NCIT:C51744" :DB-TERM-ID "UP:P0CY46" :DB-TERM-ID "UP:P04412"
+                                :DB-TERM-ID "GO:0005006" :DB-TERM-ID "NCIT:C17068" :DB-TERM-ID "NCIT:C18436" :SPEC
+                                ONT::THE :NAME-OF W::EGFR :EQUALS ONT::V60386)
+                               (ONT::TERM ONT::V61333 :INSTANCE-OF ONT::GENE-PROTEIN :DRUM
+                                ((:DRUM
+                                  (TERM :ID HGNC::|3236| :NAME "epidermal growth factor receptor" :SCORE 0.85542
+                                   :MATCHES ((MATCH :SCORE 0.85542 :MATCHED "EGFR" :STATUS "Approved Symbol" :EXACT 1))
+                                   :DBXREFS (UP::P00533) :ONT-TYPES (ONT::GENE))
+                                  (TERM :ID NCIT::C51744 :NAME "EGFR" :SCORE 0.85542 :MATCHES
+                                   ((MATCH :SCORE 0.85542 :MATCHED "EGFR" :STATUS "name" :EXACT 1)) :MAPPINGS
+                                   ((MAP :THROUGH
+                                         (CONCEPT NCIT::C16612
+                                          (SENSE (MORPH (POS N) (WORD GENE))
+                                           (PROVENANCE (NAME NCIT)
+                                            (FILENAME
+
+"/Users/mark/Projects/CLiC/cwc-integ/trips/bob/src/config/lisp/../../../src/TextTagger/drum-dsl/NCIT/01661.lisp"))))
+                                         :TO ONT::GENE))
+                                   :ONT-TYPES (ONT::GENE))
+                                  (TERM :ID UP::P0CY46 :NAME "Epidermal growth factor receptor" :SCORE 0.85368 :MATCHES
+                                   ((MATCH :SCORE 0.85368 :MATCHED "egfr" :STATUS "RecName: Short" :ALL-CAPS-NO-CAPS
+                                     1))
+                                   :DBXREFS (XFAM::PF00757 XFAM::PF14843 XFAM::PF07714 XFAM::PF01030) :ONT-TYPES
+                                   (ONT::PROTEIN))
+                                  (TERM :ID UP::P04412 :NAME "Epidermal growth factor receptor" :SCORE 0.85368 :MATCHES
+                                   ((MATCH :SCORE 0.85368 :MATCHED "egfr" :STATUS "RecName: Short" :ALL-CAPS-NO-CAPS
+                                     1))
+                                   :DBXREFS (XFAM::PF00757 XFAM::PF14843 XFAM::PF07714 XFAM::PF01030) :ONT-TYPES
+                                   (ONT::PROTEIN))
+                                  (TERM :ID GO::|0005006| :NAME "epidermal growth factor-activated receptor activity"
+                                   :SCORE 0.71084 :MATCHES
+                                   ((MATCH :SCORE 0.71084 :MATCHED "EGFR" :STATUS "EXACT synonym" :EXACT 1)) :ONT-TYPES
+                                   (ONT::PROTEIN))
+                                  (TERM :ID NCIT::C17068 :NAME "epidermal growth factor receptor" :SCORE 0.71084
+                                   :MATCHES ((MATCH :SCORE 0.71084 :MATCHED "EGFR" :STATUS "synonym" :EXACT 1))
+                                   :MAPPINGS
+                                   ((MAP :THROUGH
+                                         (CONCEPT NCIT::C17021
+                                          (SENSE (MORPH (POS N) (WORD PROTEIN))
+                                           (PROVENANCE (NAME NCIT)
+                                            (FILENAME
+
+"/Users/mark/Projects/CLiC/cwc-integ/trips/bob/src/config/lisp/../../../src/TextTagger/drum-dsl/NCIT/01702.lisp"))))
+                                         :TO ONT::PROTEIN))
+                                   :ONT-TYPES (ONT::PROTEIN))
+                                  (TERM :ID NCIT::C18436 :NAME "soluble ERBB-1 protein" :SCORE 0.71084 :MATCHES
+                                   ((MATCH :SCORE 0.71084 :MATCHED "EGFR" :STATUS "synonym" :EXACT 1)) :MAPPINGS
+                                   ((MAP :THROUGH
+                                         (CONCEPT NCIT::C17021
+                                          (SENSE (MORPH (POS N) (WORD PROTEIN))
+                                           (PROVENANCE (NAME NCIT)
+                                            (FILENAME
+
+"/Users/mark/Projects/CLiC/cwc-integ/trips/bob/src/config/lisp/../../../src/TextTagger/drum-dsl/NCIT/01702.lisp"))))
+                                         :TO ONT::PROTEIN))
+                                   :ONT-TYPES (ONT::PROTEIN))))
+                                :NAME W::EGFR :DBID "HGNC:3236" :DBNAME "epidermal growth factor receptor" :DB-TERM-ID
+                                "HGNC:3236" :DB-TERM-ID "NCIT:C51744" :DB-TERM-ID "UP:P0CY46" :DB-TERM-ID "UP:P04412"
+                                :DB-TERM-ID "GO:0005006" :DB-TERM-ID "NCIT:C17068" :DB-TERM-ID "NCIT:C18436" :SPEC
+                                ONT::THE :NAME-OF W::EGFR :EQUALS ONT::V60386)
+                               (ONT::THE ONT::V61438 :INSTANCE-OF ONT::GENE-PROTEIN :SPEC ONT::THE :SEQUENCE
+                                (ONT::V61325 ONT::V61333) :NAME-OF W::EGFR-PUNC-MINUS-EGFR :LEX W::EGFR)
+                               (ONT::TERM ONT::V60386 :INSTANCE-OF ONT::GENE-PROTEIN :DRUM
+                                ((:DRUM
+                                  (TERM :ID HGNC::|3236| :NAME "epidermal growth factor receptor" :SCORE 0.85542
+                                   :MATCHES ((MATCH :SCORE 0.85542 :MATCHED "EGFR" :STATUS "Approved Symbol" :EXACT 1))
+                                   :DBXREFS (UP::P00533) :ONT-TYPES (ONT::GENE))
+                                  (TERM :ID NCIT::C51744 :NAME "EGFR" :SCORE 0.85542 :MATCHES
+                                   ((MATCH :SCORE 0.85542 :MATCHED "EGFR" :STATUS "name" :EXACT 1)) :MAPPINGS
+                                   ((MAP :THROUGH
+                                         (CONCEPT NCIT::C16612
+                                          (SENSE (MORPH (POS N) (WORD GENE))
+                                           (PROVENANCE (NAME NCIT)
+                                            (FILENAME
+
+"/Users/mark/Projects/CLiC/cwc-integ/trips/bob/src/config/lisp/../../../src/TextTagger/drum-dsl/NCIT/01661.lisp"))))
+                                         :TO ONT::GENE))
+                                   :ONT-TYPES (ONT::GENE))
+                                  (TERM :ID UP::P0CY46 :NAME "Epidermal growth factor receptor" :SCORE 0.85368 :MATCHES
+                                   ((MATCH :SCORE 0.85368 :MATCHED "egfr" :STATUS "RecName: Short" :ALL-CAPS-NO-CAPS
+                                     1))
+                                   :DBXREFS (XFAM::PF00757 XFAM::PF14843 XFAM::PF07714 XFAM::PF01030) :ONT-TYPES
+                                   (ONT::PROTEIN))
+                                  (TERM :ID UP::P04412 :NAME "Epidermal growth factor receptor" :SCORE 0.85368 :MATCHES
+                                   ((MATCH :SCORE 0.85368 :MATCHED "egfr" :STATUS "RecName: Short" :ALL-CAPS-NO-CAPS
+                                     1))
+                                   :DBXREFS (XFAM::PF00757 XFAM::PF14843 XFAM::PF07714 XFAM::PF01030) :ONT-TYPES
+                                   (ONT::PROTEIN))
+                                  (TERM :ID GO::|0005006| :NAME "epidermal growth factor-activated receptor activity"
+                                   :SCORE 0.71084 :MATCHES
+                                   ((MATCH :SCORE 0.71084 :MATCHED "EGFR" :STATUS "EXACT synonym" :EXACT 1)) :ONT-TYPES
+                                   (ONT::PROTEIN))
+                                  (TERM :ID NCIT::C17068 :NAME "epidermal growth factor receptor" :SCORE 0.71084
+                                   :MATCHES ((MATCH :SCORE 0.71084 :MATCHED "EGFR" :STATUS "synonym" :EXACT 1))
+                                   :MAPPINGS
+                                   ((MAP :THROUGH
+                                         (CONCEPT NCIT::C17021
+                                          (SENSE (MORPH (POS N) (WORD PROTEIN))
+                                           (PROVENANCE (NAME NCIT)
+                                            (FILENAME
+
+"/Users/mark/Projects/CLiC/cwc-integ/trips/bob/src/config/lisp/../../../src/TextTagger/drum-dsl/NCIT/01702.lisp"))))
+                                         :TO ONT::PROTEIN))
+                                   :ONT-TYPES (ONT::PROTEIN))
+                                  (TERM :ID NCIT::C18436 :NAME "soluble ERBB-1 protein" :SCORE 0.71084 :MATCHES
+                                   ((MATCH :SCORE 0.71084 :MATCHED "EGFR" :STATUS "synonym" :EXACT 1)) :MAPPINGS
+                                   ((MAP :THROUGH
+                                         (CONCEPT NCIT::C17021
+                                          (SENSE (MORPH (POS N) (WORD PROTEIN))
+                                           (PROVENANCE (NAME NCIT)
+                                            (FILENAME
+
+"/Users/mark/Projects/CLiC/cwc-integ/trips/bob/src/config/lisp/../../../src/TextTagger/drum-dsl/NCIT/01702.lisp"))))
+                                         :TO ONT::PROTEIN))
+                                   :ONT-TYPES (ONT::PROTEIN))))
+                                :NAME W::EGFR :DBID "HGNC:3236" :DBNAME "epidermal growth factor receptor" :DB-TERM-ID
+                                "HGNC:3236" :DB-TERM-ID "NCIT:C51744" :DB-TERM-ID "UP:P0CY46" :DB-TERM-ID "UP:P04412"
+                                :DB-TERM-ID "GO:0005006" :DB-TERM-ID "NCIT:C17068" :DB-TERM-ID "NCIT:C18436" :SPEC
+                                ONT::THE :NAME-OF W::EGFR)
+                               (ONT::TERM ONT::V61394 :INSTANCE-OF ONT::MACROMOLECULAR-COMPLEX :M-SEQUENCE
+                                (ONT::V61325 ONT::V61333) :SPEC ONT::THE :ASSOC-WITH ONT::V61438 :EQUALS ONT::V60386)
+                               (ONT::TERM ONT::V61429 :INSTANCE-OF ONT::GENE-PROTEIN :DRUM
+                                ((:DRUM
+                                  (TERM :ID HGNC::|4566| :NAME "growth factor receptor bound protein 2" :SCORE 0.85542
+                                   :MATCHES ((MATCH :SCORE 0.85542 :MATCHED "GRB2" :STATUS "Approved Symbol" :EXACT 1))
+                                   :DBXREFS (UP::P62993) :ONT-TYPES (ONT::GENE))
+                                  (TERM :ID NCIT::C52395 :NAME "GRB2" :SCORE 0.85542 :MATCHES
+                                   ((MATCH :SCORE 0.85542 :MATCHED "GRB2" :STATUS "name" :EXACT 1)) :MAPPINGS
+                                   ((MAP :THROUGH
+                                         (CONCEPT NCIT::C16612
+                                          (SENSE (MORPH (POS N) (WORD GENE))
+                                           (PROVENANCE (NAME NCIT)
+                                            (FILENAME
+
+"/Users/mark/Projects/CLiC/cwc-integ/trips/bob/src/config/lisp/../../../src/TextTagger/drum-dsl/NCIT/01661.lisp"))))
+                                         :TO ONT::GENE))
+                                   :ONT-TYPES (ONT::GENE))
+                                  (TERM :ID NCIT::C26222 :NAME "growth factor receptor-bound protein-2" :SCORE 0.71084
+                                   :MATCHES
+                                   ((MATCH :SCORE 0.71084 :MATCHED "GRB2" :STATUS "synonym" :EXACT 1)
+                                    (MATCH :SCORE 0.71082 :MATCHED "GRB-2" :STATUS "synonym" :NO-DASH-DASH 1 :EXACT 1))
+                                   :MAPPINGS
+                                   ((MAP :THROUGH
+                                         (CONCEPT NCIT::C17021
+                                          (SENSE (MORPH (POS N) (WORD PROTEIN))
+                                           (PROVENANCE (NAME NCIT)
+                                            (FILENAME
+
+"/Users/mark/Projects/CLiC/cwc-integ/trips/bob/src/config/lisp/../../../src/TextTagger/drum-dsl/NCIT/01702.lisp"))))
+                                         :TO ONT::PROTEIN))
+                                   :ONT-TYPES (ONT::PROTEIN))))
+                                :NAME W::GRB-2 :DBID "HGNC:4566" :DBNAME "growth factor receptor bound protein 2"
+                                :DB-TERM-ID "HGNC:4566" :DB-TERM-ID "NCIT:C52395" :DB-TERM-ID "NCIT:C26222" :SPEC
+                                ONT::THE :NAME-OF W::GRB-2)
+                               (ONT::EVENT ONT::V61411 :INSTANCE-OF ONT::BIND :AGENT ONT::V61394 :AFFECTED ONT::V61429
+                                :FORCE ONT::TRUE :TYPE (:* ONT::ATTACH W::BIND) :SPEC ONT::F :TENSE W::PRES)))

--- a/bioagents/tests/mra_test.py
+++ b/bioagents/tests/mra_test.py
@@ -247,6 +247,32 @@ def test_get_matching_statements():
 # MRA integration tests
 # #####################
 
+def test_description_not_list_handling():
+    mm = MRA_Module(testing=True)
+    content = KQMLList.from_string(
+        '(BUILD-MODEL :DESCRIPTION ('
+        ':TYPE "Inhibition" '
+        ':SUBJ (:NAME "SB-525334" '
+        '       :DB--REFS (:+TYPE+ "ONT::GENE-PROTEIN" '
+        '                  :+TEXT+ "SB525334"'
+        '                  :+PUBCHEM+ "9967941")) '
+        ':OBJ (:NAME "TGFBR1"'
+        '      :DB--REFS (:+TYPE+ "ONT::GENE-PROTEIN" '
+        '                 :+TEXT+ "TGFBR1" '
+        '                 :+HGNC+ "11772" '
+        '                 :+UP+ "P36897" '
+        '                 :+NCIT+ "C51730")) '
+        ':OBJ--ACTIVITY "activity" '
+        ':BELIEF 1 '
+        ':EVIDENCE ((:SOURCE--API "trips" '
+        '            :SOURCE--HASH -1613118243458052451)) '
+        ':ID "ce486f46-3670-42e6-8f0e-d5f510525352" '
+        ':MATCHES--HASH "-32031145755534420"))''')
+    reply = mm.respond_build_model(content)
+    assert reply.head() == 'FAILURE', reply.to_string()
+    return
+
+
 def _get_build_model_request(text, format=None):
     content = KQMLList('BUILD-MODEL')
     if format == 'ekb':

--- a/bioagents/tests/mra_test.py
+++ b/bioagents/tests/mra_test.py
@@ -8,7 +8,7 @@ from bioagents.tests.util import ekb_from_text, ekb_kstring_from_text, \
 from bioagents.tests.integration import _IntegrationTest, _FailureTest
 from bioagents.mra.mra import MRA, make_influence_map, make_contact_map
 from bioagents.mra.mra_module import MRA_Module, ekb_from_agent, get_target, \
-    _get_matching_stmts, CAN_CHECK_STATEMENTS
+    _get_matching_stmts, CAN_CHECK_STATEMENTS, InvalidModelDescriptionError
 from nose.plugins.skip import SkipTest
 from nose.plugins.attrib import attr
 
@@ -268,9 +268,11 @@ def test_description_not_list_handling():
         '            :SOURCE--HASH -1613118243458052451)) '
         ':ID "ce486f46-3670-42e6-8f0e-d5f510525352" '
         ':MATCHES--HASH "-32031145755534420"))''')
-    reply = mm.respond_build_model(content)
-    assert reply.head() == 'FAILURE', reply.to_string()
-    return
+    try:
+        reply = mm.respond_build_model(content)
+    except InvalidModelDescriptionError:
+        return
+    assert False, "Model should have explicitly failed: " + reply.to_string()
 
 
 def _get_build_model_request(text, format=None):


### PR DESCRIPTION
Make the MRA explicitly fail (rather than just return no model) when the input is an event, rather than a list of events.