### PR TITLE
Silent negatives

### DIFF
--- a/bioagents/__init__.py
+++ b/bioagents/__init__.py
@@ -278,9 +278,10 @@ class Bioagent(KQMLModule):
 
     def say(self, message):
         """Say something to the user."""
-        msg = KQMLList('say')
-        msg.append(KQMLString(message))
-        self.request(msg)
+        if message:
+            msg = KQMLList('say')
+            msg.append(KQMLString(message))
+            self.request(msg)
 
     def _make_report_cols_html(self, stmt_list, limit=5, ev_counts=None,
                                **kwargs):

--- a/bioagents/__init__.py
+++ b/bioagents/__init__.py
@@ -286,6 +286,8 @@ class Bioagent(KQMLModule):
     def _make_report_cols_html(self, stmt_list, limit=5, ev_counts=None,
                                **kwargs):
         """Make columns listing the support given by the statement list."""
+        if not stmt_list:
+            return "No statements found."
 
         def href(ref, text):
             return '<a href=%s target="_blank">%s</a>' % (ref, text)

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -387,7 +387,6 @@ class StatementFinder(object):
         return {stmt.get_hash(): self._processor.get_source_count(stmt)
                 for stmt in stmts}
 
-
     def get_sample(self):
         """Get the sample of statements retrieved by the first query."""
         if not self._sample:

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -215,7 +215,8 @@ class MSA_Module(Bioagent):
             # Calling this success may be a bit ambitious.
             resp = KQMLPerformative('SUCCESS')
             resp.set('status', 'WORKING')
-            resp.set('relations-found', 'nil')
+            resp.set('entities-found', 'nil')
+            resp.set('num-relations-found', '0')
             resp.set('dump-limit', str(DUMP_LIMIT))
             return resp
 

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -301,8 +301,6 @@ class MSA_Module(Bioagent):
         try:
             logger.debug("Waiting for statements to finish...")
             stmts = finder.get_statements(block=True)
-            if stmts is None or not len(stmts):
-                return
             start_time = datetime.now()
             logger.info('Sending display statements.')
             self.send_provenance_for_stmts(stmts, nl_question,

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -145,7 +145,7 @@ class MSA_Module(Bioagent):
                                                 action=action,
                                                 polarity=polarity)
         stmts = finder.get_statements()
-        self.say(finder.describe())
+        self.say(finder.describe(include_negative=False))
 
         logger.info("Found %d matching statements." % len(stmts))
         if not len(stmts):
@@ -220,7 +220,7 @@ class MSA_Module(Bioagent):
             return resp
 
         agents = finder.get_other_agents()
-        self.say(finder.describe())
+        self.say(finder.describe(include_negative=False))
         resp = KQMLPerformative('SUCCESS')
         resp.set('status', 'FINISHED')
         resp.set('entities-found', self.make_cljson(agents))
@@ -245,7 +245,7 @@ class MSA_Module(Bioagent):
             # TODO: Handle this more gracefully, if possible.
             return self.make_failure('MISSING_MECHANISM')
         num_stmts = len(stmts)
-        self.say(finder.describe())
+        self.say(finder.describe(include_negative=False))
         resp = KQMLPerformative('SUCCESS')
         resp.set('some-relations-found', 'TRUE' if num_stmts else 'FALSE')
         resp.set('num-relations-found', str(num_stmts))


### PR DESCRIPTION
Make some minor changes to the way we handle responding to negative cases:
- Do not respond directly to the dialogue in such cases, and
- Don't just remain silent in the provenance if there were no results for a query.