### PR TITLE
Handle adding duplicate component

### DIFF
--- a/bioagents/mra/mra_module.py
+++ b/bioagents/mra/mra_module.py
@@ -472,7 +472,7 @@ class MRA_Module(Bioagent):
                     matched = idp.statements
                     logger.info("Found %d statements supporting %s"
                                 % (len(matched), stmt))
-                except BioagentException as e:
+                except Exception as e:
                     logger.error("Got exception while looking for support for "
                                  "%s" % stmt)
                     logger.exception(e)

--- a/bioagents/tests/tra_test.py
+++ b/bioagents/tests/tra_test.py
@@ -24,8 +24,8 @@ def test_get_time_interval_full():
     ts = '(:lower-bound 2 :upper-bound 4 :unit "hour")'
     lst = KQMLList.from_string(ts)
     ti = tra_module.get_time_interval(lst)
-    assert ti.lb == 2*units.hour, ti.lb
-    assert ti.ub == 4*units.hour, ti.ub
+    assert ti.lb == 2.0*units.hour, ti.lb
+    assert ti.ub == 4.0*units.hour, ti.ub
     assert ti.get_lb_seconds() == 7200
     assert ti.get_ub_seconds() == 14400
 
@@ -35,7 +35,7 @@ def test_get_time_interval_ub():
     lst = KQMLList.from_string(ts)
     ti = tra_module.get_time_interval(lst)
     assert ti.lb is None
-    assert ti.ub == 4*units.hours, ti.ub
+    assert ti.ub == 4.0*units.hours, ti.ub
     assert ti.get_ub_seconds() == 14400
 
 
@@ -43,7 +43,7 @@ def test_get_time_interval_lb():
     ts = '(:lower-bound 4 :unit "hour")'
     lst = KQMLList.from_string(ts)
     ti = tra_module.get_time_interval(lst)
-    assert ti.lb == 4*units.hours, ti.lb
+    assert ti.lb == 4.0*units.hours, ti.lb
     assert ti.ub is None
     assert ti.get_lb_seconds() == 14400
 
@@ -67,7 +67,7 @@ def test_molecular_quantity_conc1():
     lst = KQMLList.from_string(s)
     mq = tra_module.get_molecular_quantity(lst)
     assert mq.quant_type == 'concentration'
-    assert mq.value == 2 * units.micro * units.mol / units.liter, mq.value
+    assert mq.value == 2.0 * units.micro * units.mol / units.liter, mq.value
 
 
 def test_molecular_quantity_conc2():
@@ -75,7 +75,7 @@ def test_molecular_quantity_conc2():
     lst = KQMLList.from_string(s)
     mq = tra_module.get_molecular_quantity(lst)
     assert mq.quant_type == 'concentration'
-    assert mq.value == 200 * units.nano * units.mol / units.liter, mq.value
+    assert mq.value == 200.0 * units.nano * units.mol / units.liter, mq.value
 
 
 @raises(tra.InvalidMolecularQuantityError)
@@ -128,7 +128,8 @@ def test_molecular_quantity_ref():
     lst = KQMLList.from_string(s)
     mqr = tra_module.get_molecular_quantity_ref(lst)
     assert mqr.quant_type == 'total'
-    assert len(mqr.entity.bound_conditions) == 1, len(mqr.entity.bound_conditions)
+    assert len(mqr.entity.bound_conditions) == 1, \
+        len(mqr.entity.bound_conditions)
 
 
 def test_molecular_quantity_ref2():
@@ -136,7 +137,8 @@ def test_molecular_quantity_ref2():
     lst = KQMLList.from_string(s)
     mqr = tra_module.get_molecular_quantity_ref(lst)
     assert mqr.quant_type == 'initial'
-    assert len(mqr.entity.bound_conditions) == 1, len(mqr.entity.bound_conditions)
+    assert len(mqr.entity.bound_conditions) == 1, \
+        len(mqr.entity.bound_conditions)
 
 
 @raises(tra.InvalidMolecularQuantityRefError)

--- a/bioagents/tests/tra_test.py
+++ b/bioagents/tests/tra_test.py
@@ -24,8 +24,8 @@ def test_get_time_interval_full():
     ts = '(:lower-bound 2 :upper-bound 4 :unit "hour")'
     lst = KQMLList.from_string(ts)
     ti = tra_module.get_time_interval(lst)
-    assert ti.lb == 2*units.hour
-    assert ti.ub == 4*units.hour
+    assert ti.lb == 2*units.hour, ti.lb
+    assert ti.ub == 4*units.hour, ti.ub
     assert ti.get_lb_seconds() == 7200
     assert ti.get_ub_seconds() == 14400
 
@@ -35,7 +35,7 @@ def test_get_time_interval_ub():
     lst = KQMLList.from_string(ts)
     ti = tra_module.get_time_interval(lst)
     assert ti.lb is None
-    assert ti.ub == 4*units.hours
+    assert ti.ub == 4*units.hours, ti.ub
     assert ti.get_ub_seconds() == 14400
 
 
@@ -43,7 +43,7 @@ def test_get_time_interval_lb():
     ts = '(:lower-bound 4 :unit "hour")'
     lst = KQMLList.from_string(ts)
     ti = tra_module.get_time_interval(lst)
-    assert ti.lb == 4*units.hours
+    assert ti.lb == 4*units.hours, ti.lb
     assert ti.ub is None
     assert ti.get_lb_seconds() == 14400
 
@@ -67,7 +67,7 @@ def test_molecular_quantity_conc1():
     lst = KQMLList.from_string(s)
     mq = tra_module.get_molecular_quantity(lst)
     assert mq.quant_type == 'concentration'
-    assert mq.value == 2 * units.micro * units.mol / units.liter
+    assert mq.value == 2 * units.micro * units.mol / units.liter, mq.value
 
 
 def test_molecular_quantity_conc2():
@@ -75,7 +75,7 @@ def test_molecular_quantity_conc2():
     lst = KQMLList.from_string(s)
     mq = tra_module.get_molecular_quantity(lst)
     assert mq.quant_type == 'concentration'
-    assert mq.value == 200 * units.nano * units.mol / units.liter
+    assert mq.value == 200 * units.nano * units.mol / units.liter, mq.value
 
 
 @raises(tra.InvalidMolecularQuantityError)

--- a/bioagents/tra/tra.py
+++ b/bioagents/tra/tra.py
@@ -20,6 +20,7 @@ from indra.assemblers.english import assembler as english_assembler
 from pysb import Observable
 from pysb.integrate import Solver
 from pysb.export.kappa import KappaExporter
+from pysb.core import ComponentDuplicateNameError
 import bioagents.tra.model_checker as mc
 import matplotlib
 from bioagents import BioagentException, get_img_path
@@ -399,7 +400,10 @@ def get_create_observable(model, agent):
             (site_pattern, monomer.name)
         raise MissingMonomerSiteError(msg)
     obs = Observable(obs_name, monomer(site_pattern))
-    model.add_component(obs)
+    try:
+        model.add_component(obs)
+    except ComponentDuplicateNameError as e:
+        pass
     return obs
 
 


### PR DESCRIPTION
Handle ComponentDuplicateNameError in order to be able to run multiple queries about the same entity.