### PR TITLE
Extend synonyms in biosense and use gilda

### DIFF
--- a/bioagents/biosense/biosense_module.py
+++ b/bioagents/biosense/biosense_module.py
@@ -193,12 +193,13 @@ class BioSense_Module(Bioagent):
             return self.make_failure('SYNONYMS_UNKNOWN')
         else:
             syns_kqml = KQMLList()
-            for s in synonyms:
+            for s in synonyms[:10]:
                 entry = KQMLList()
                 entry.sets(':name', s)
                 syns_kqml.append(entry)
             msg = KQMLList('SUCCESS')
             msg.set('synonyms', syns_kqml)
+            msg.set('num_synonyms', str(len(synonyms)))
         return msg
 
 

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -312,12 +312,11 @@ class StatementFinder(object):
                                                           other_role)
             for ag in other_agents:
                 gr = self.query.get_agent_grounding(ag)
-                counts[gr] += ev_totals.get(stmt.get_hash(), 0)
+                hash = stmt.get_hash()
+                count = 0 if (hash not in ev_totals or not ev_totals[hash]) \
+                    else ev_totals[hash]
+                counts[gr] += count
                 oa_dict[gr].append(ag)
-
-        def get_aggregate_agent(agents, dbi, dbn):
-            agent = Agent(agents[0].name, db_refs={dbn: dbi})
-            return agent
 
         # Create a list of groundings sorted with the most frequent first.
         # We add t itself as a second element to the tuple to make sure the
@@ -1094,3 +1093,9 @@ class EntityTypeFilter(object):
 
 
 entity_type_filter = EntityTypeFilter()
+
+
+def get_aggregate_agent(agents, dbi, dbn):
+    agent = Agent(agents[0].name, db_refs={dbn: dbi})
+    return agent
+

--- a/bioagents/tests/biosense_test.py
+++ b/bioagents/tests/biosense_test.py
@@ -380,12 +380,13 @@ def test_get_synonyms_fplx():
     assert example_synonyms.issubset(synonyms), synonyms
 
 
-@raises(SynonymsUnknownError)
-def test_get_synonyms_no_synonyms_for_type():
+def test_get_synonyms_chemical():
     """raises InvalidAgentError when the agent is not recognized or if the
     input submitted is not valid XML or is not in the correct format
     """
-    bs.get_synonyms(Bioagent.get_agent(agent_clj_from_text('vemurafenib')))
+    synonyms = bs.get_synonyms(Bioagent.get_agent(
+        agent_clj_from_text('vemurafenib')))
+    assert synonyms
 
 
 # BioSense module unit tests
@@ -478,6 +479,6 @@ def test_respond_get_synonyms():
     assert res.head() == 'SUCCESS'
     syns = res.get('synonyms')
     syn_strs = [s.gets(':name') for s in syns]
-    assert 'MAP2K1' in syn_strs
-    assert 'MEK1' in syn_strs
-    assert 'MKK1' in syn_strs
+    assert 'MAP2K1' in syn_strs, syn_strs
+    assert 'MEK1' in syn_strs, syn_strs
+    assert 'MKK1' in syn_strs, syn_strs

--- a/bioagents/tests/biosense_test.py
+++ b/bioagents/tests/biosense_test.py
@@ -389,6 +389,14 @@ def test_get_synonyms_chemical():
     assert synonyms
 
 
+@raises(SynonymsUnknownError)
+def test_get_synonyms_ungrounded():
+    """raises InvalidAgentError when the agent is not recognized or if the
+    input submitted is not valid XML or is not in the correct format
+    """
+    bs.get_synonyms(Agent('x', db_refs={'xxx': '123'}))
+
+
 # BioSense module unit tests
 def test_respond_choose_sense():
     bs = BioSense_Module(testing=True)
@@ -482,3 +490,4 @@ def test_respond_get_synonyms():
     assert 'MAP2K1' in syn_strs, syn_strs
     assert 'MEK1' in syn_strs, syn_strs
     assert 'MKK1' in syn_strs, syn_strs
+    assert res.get('num_synonyms') == '23', res


### PR DESCRIPTION
This PR extends the ability to report synonyms to namespaces beyond UP and FPLX by using Gilda's get_name function.