### PR TITLE
Contextual constraints in MSA queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ script:
   - if [[ "$TRAVIS_EVENT_TYPE" == "cron" ]]; then
         export RUN_SLOW=true;
     fi
-  - export NOSEATTR="";
   - if [[ $TRAVIS_PULL_REQUEST != "false" ]]; then
       export NOSEATTR="!nonpublic,$NOSEATTR";
     fi

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -181,10 +181,14 @@ class MSA_Module(Bioagent):
         filter_agents = Bioagent.get_agent(kfilter_agents) if kfilter_agents \
             else []
 
+        kcontext_agents = content.get('context')
+        context_agents = Bioagent.get_agent(kcontext_agents) if kcontext_agents \
+            else []
+
         stmt_type = content.gets('type')
         if stmt_type == 'unknown':
             stmt_type = None
-        return subj, obj, stmt_type, filter_agents
+        return subj, obj, stmt_type, filter_agents, context_agents
 
     def _send_provenance_async(self, finder, desc):
         q = finder.query
@@ -211,12 +215,14 @@ class MSA_Module(Bioagent):
     def respond_find_relations_from_literature(self, content):
         """Find statements matching some subject, verb, object information."""
         try:
-            subj, obj, stmt_type, filter_agents = self._get_query_info(content)
+            subj, obj, stmt_type, filter_agents, context_agents = \
+                self._get_query_info(content)
             finder = \
                 self.msa.find_mechanism_from_input(subj, obj, None, stmt_type,
                                                    ev_limit=3, persist=False,
                                                    timeout=5,
-                                                   filter_agents=filter_agents)
+                                                   filter_agents=filter_agents,
+                                                   context_agents=context_agents)
             self._send_provenance_async(finder,
                                         'finding statements that match')
         except MSALookupError as mle:
@@ -251,12 +257,14 @@ class MSA_Module(Bioagent):
     def respond_confirm_relation_from_literature(self, content):
         """Confirm a protein-protein interaction given subject, object, verb"""
         try:
-            subj, obj, stmt_type, filter_agents = self._get_query_info(content)
+            subj, obj, stmt_type, filter_agents, context_agents = \
+                self._get_query_info(content)
             finder = \
                 self.msa.find_mechanism_from_input(subj, obj, None, stmt_type,
                                                    ev_limit=5, persist=False,
                                                    timeout=5,
-                                                   filter_agents=filter_agents)
+                                                   filter_agents=filter_agents,
+                                                   context_agents=context_agents)
             self._send_provenance_async(finder,
                 'confirming that some statements match')
         except MSALookupError as mle:

--- a/bioagents/tests/dtda_test.py
+++ b/bioagents/tests/dtda_test.py
@@ -396,8 +396,8 @@ class TestFindDiseaseTargets2(_IntegrationTest):
         protein = self.bioagent.get_agent(output.get('protein'))
         assert protein.name == 'KRAS'
         assert protein.db_refs['HGNC'] == '6407'
-        assert output.gets('prevalence') == '0.19'
-        assert output.gets('functional-effect') == 'ACTIVE'
+        assert output.gets('prevalence') == '0.18', output
+        assert output.gets('functional-effect') == 'ACTIVE', output
 
 
 @attr('nonpublic')
@@ -467,7 +467,7 @@ class TestFindTreatment2(_IntegrationTest):
 
     def check_response_to_message(self, output):
         assert output.head() == 'SUCCESS', output
-        assert output.gets('prevalence') == '0.19', output.get('prevalence')
+        assert output.gets('prevalence') == '0.18', output.get('prevalence')
         assert len(output.get('drugs')) == 0
 
 

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -141,6 +141,8 @@ covid19 = Bioagent.make_cljson(
           db_refs={"TEXT": "COVID-19",
                    "NCIT": "C171133",
                    "TYPE": "ONT::MEDICAL-DISORDERS-AND-CONDITIONS"}))
+melanoma = Bioagent.make_cljson(Agent('Melanoma',
+                                      db_refs={'MESH': 'D008545'}))
 NONE = KQMLList()
 
 
@@ -189,6 +191,24 @@ class TestMSATypeAndSourceBRAF(_TestMsaGeneralLookup):
 
     def check_response_to_type_and_source(self, output):
         assert _agent_name_found(output, 'ERK')
+        nrel = int(output.gets('num-relations-found'))
+        assert nrel > 100, nrel  # 195 when this was written
+        return self._check_find_response(output)
+
+
+@attr('nonpublic')
+class TestMSAContextBRAF(_TestMsaGeneralLookup):
+    def create_type_and_target(self):
+        return self._get_content('FIND-RELATIONS-FROM-LITERATURE',
+                                 type='Phosphorylation',
+                                 source=braf,
+                                 target=NONE,
+                                 context=KQMLList([melanoma]))
+
+    def check_response_to_type_and_target(self, output):
+        assert _agent_name_found(output, 'ERK')
+        nrel = int(output.gets('num-relations-found'))
+        assert 10 < nrel < 100, nrel
         return self._check_find_response(output)
 
 

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -196,7 +196,7 @@ class TestMSATypeAndSourceBRAF(_TestMsaGeneralLookup):
         return self._check_find_response(output)
 
 
-@attr('nonpublic')
+@attr('nonpublic', 'notravis')
 class TestMSAContextBRAF(_TestMsaGeneralLookup):
     def create_type_and_target(self):
         return self._get_content('FIND-RELATIONS-FROM-LITERATURE',


### PR DESCRIPTION
This PR adds support for contextual constraints on MSA queries. For now, MeSH terms are taken as is while https://github.com/indralab/indra_db/pull/118 is pending, but support for including child terms is also implemented.