### PR TITLE
Update to the new INDRA DB-REST client.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
         pip install -U networkx==2.3
     - name: Run unit tests
       env:
-        INDRA_DB_REST_URL: ${{ secrets.INDRA_DB_REST_URL }}/dev
+        INDRA_DB_REST_URL: ${{ secrets.INDRA_DB_REST_URL }}
         INDRA_DB_REST_API_KEY: ${{ secrets.INDRA_DB_REST_API_KEY }}
         INDRA_ONTOLOGY_URL: ${{ secrets.INDRA_ONTOLOGY_URL }}
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         # where these repos are cloned from the latest source
         pip install git+https://github.com/pysb/pysb.git
         pip install git+https://github.com/bgyori/pykqml.git
-        pip install git+https://github.com/pagreene/indra.git@api-update
+        pip install git+https://github.com/sorgerlab/indra.git
         # Here we install ndex2 and then re-upgrate networkx since ndex2 downgrades it
         pip install pygraphviz ndex2==1.2.0.58
         pip install -U networkx==2.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,13 +36,13 @@ jobs:
         # where these repos are cloned from the latest source
         pip install git+https://github.com/pysb/pysb.git
         pip install git+https://github.com/bgyori/pykqml.git
-        pip install git+https://github.com/sorgerlab/indra.git
+        pip install git+https://github.com/sorgerlab/indra.git@api-update
         # Here we install ndex2 and then re-upgrate networkx since ndex2 downgrades it
         pip install pygraphviz ndex2==1.2.0.58
         pip install -U networkx==2.3
     - name: Run unit tests
       env:
-        INDRA_DB_REST_URL: ${{ secrets.INDRA_DB_REST_URL }}
+        INDRA_DB_REST_URL: ${{ secrets.INDRA_DB_REST_URL }}/dev
         INDRA_DB_REST_API_KEY: ${{ secrets.INDRA_DB_REST_API_KEY }}
         INDRA_ONTOLOGY_URL: ${{ secrets.INDRA_ONTOLOGY_URL }}
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         # where these repos are cloned from the latest source
         pip install git+https://github.com/pysb/pysb.git
         pip install git+https://github.com/bgyori/pykqml.git
-        pip install git+https://github.com/sorgerlab/indra.git@api-update
+        pip install git+https://github.com/pagreene/indra.git@api-update
         # Here we install ndex2 and then re-upgrate networkx since ndex2 downgrades it
         pip install pygraphviz ndex2==1.2.0.58
         pip install -U networkx==2.3

--- a/bioagents/dtda/dtda.py
+++ b/bioagents/dtda/dtda.py
@@ -232,9 +232,9 @@ class DTDA(object):
 
         if agent.name not in self.sub_statements:
             logger.info("Looking up: %s" % agent.name)
-            self.sub_statements[agent.name] \
-                = get_statements(agents=[agent.db_refs['HGNC'] + '@HGNC'],
-                                 stmt_type='ActiveForm', simple_response=True)
+            processor = get_statements(agents=[agent.db_refs['HGNC'] + '@HGNC'],
+                                       stmt_type='ActiveForm')
+            self.sub_statements[agent.name] = processor.statements
 
         for stmt in self.sub_statements[agent.name]:
             mutations = stmt.agent.mutations

--- a/bioagents/mra/model_diagnoser.py
+++ b/bioagents/mra/model_diagnoser.py
@@ -131,8 +131,9 @@ class ModelDiagnoser(object):
         obj = query_agent(obj_agent)
         if not (subj and obj):
             return []
-        stmts = get_statements(subject=subj, object=obj, persist=False,
-                               ev_limit=10, simple_response=True)
+        ip = get_statements(subject=subj, object=obj, persist=False,
+                            ev_limit=10)
+        stmts = ip.statements
         stmts.sort(key=lambda s: len(s.evidence), reverse=True)
         end_ix = len(stmts) if len(stmts) < num_statements else num_statements
         return stmts[0:end_ix], subj_agent, obj_agent

--- a/bioagents/mra/mra_module.py
+++ b/bioagents/mra/mra_module.py
@@ -618,7 +618,6 @@ def _get_matching_stmts(stmt_ref):
                                     'something other than None.')
     kwargs['ev_limit'] = 2
     kwargs['persist'] = False
-    kwargs['simple_response'] = False
     return get_statements(stmt_type=stmt_type, **kwargs)
 
 

--- a/bioagents/mra/sbgn_colorizer.py
+++ b/bioagents/mra/sbgn_colorizer.py
@@ -37,10 +37,9 @@ def is_mutation_activating(gene_name, mutation_status):
         database says the mutation is inhibiting, None if the database doesn't
         say
     """
-    statements = get_statements(agents=[gene_name], stmt_type='ActiveForm',
-                                simple_response=True)
+    ip = get_statements(agents=[gene_name], stmt_type='ActiveForm')
     print('ActiveForm statements involving', gene_name)
-    for statement in statements:
+    for statement in ip.statements:
         print(statement)
 
 

--- a/bioagents/msa/exceptions.py
+++ b/bioagents/msa/exceptions.py
@@ -1,0 +1,2 @@
+class EntityError(ValueError):
+    pass

--- a/bioagents/msa/local_query.py
+++ b/bioagents/msa/local_query.py
@@ -92,7 +92,7 @@ class LocalQueryProcessor:
     def _filter_stmts_by_query(self, query, all_stmts):
         if isinstance(query, HasAgent):
             stmts = \
-                self._get_stmts_by_key_role((query.agent_id, query.namespace),
+                self._get_stmts_by_key_role((query.namespace, query.agent_id),
                                             query.role)
             if all_stmts:
                 return self._get_intersection(all_stmts, stmts)

--- a/bioagents/msa/local_query.py
+++ b/bioagents/msa/local_query.py
@@ -99,8 +99,7 @@ class LocalQueryProcessor:
             else:
                 return stmts
         elif isinstance(query, HasType):
-            self._filter_for_type(all_stmts, query.stmt_types[0])
-            return all_stmts
+            return self._filter_for_type(all_stmts, query.stmt_types[0])
         else:
             logger.warning("Query {query} not handled.")
             return all_stmts

--- a/bioagents/msa/local_query.py
+++ b/bioagents/msa/local_query.py
@@ -1,12 +1,15 @@
 import os
-import logging
 import pickle
+import logging
 import requests
 from collections import defaultdict
+
 from indra.statements import *
+from indra.sources.indra_db_rest.query import Or, And, HasType, HasAgent
 from indra.assemblers.html.assembler import get_available_source_counts
 from indra.util.statement_presentation import _get_available_ev_source_counts
 
+from bioagents.msa.exceptions import EntityError
 
 logger = logging.getLogger(__name__)
 
@@ -35,18 +38,16 @@ class LocalQueryProcessor:
         self.statements = []
 
     def get_statements(self, subject=None, object=None, agents=None,
-                       stmt_type=None,
-                       use_exact_type=False, persist=True,
-                       simple_response=False,
-                       *api_args, **api_kwargs):
+                       stmt_type=None, **ignored_kwargs):
+        all_stmts = None
         if subject:
             subj_stmts = self._get_stmts_by_key_role(
-                self._tuple_from_at_key(subject), 'SUBJ')
+                self._tuple_from_at_key(subject), 'SUBJECT')
             all_stmts = subj_stmts
 
         if object:
             obj_stmts = self._get_stmts_by_key_role(
-                self._tuple_from_at_key(object), 'OBJ')
+                self._tuple_from_at_key(object), 'OBJECT')
             all_stmts = obj_stmts
 
         if subject and object:
@@ -62,10 +63,46 @@ class LocalQueryProcessor:
             else:
                 all_stmts = ag1_stmts
 
+        if all_stmts is None:
+            raise EntityError("Did not get any usable entity constraints!")
+
         stmts = self._filter_for_type(all_stmts, stmt_type)
         stmts = self.sort_statements(stmts)
         self.statements = stmts
         return self
+
+    def get_statements_from_query(self, query, **ignored_kwargs):
+        all_stmts = None
+        if isinstance(query, And):
+            # Sort the queries to ensure that type queries come last.
+            q_list = sorted(query.queries,
+                            key=lambda q: 1 if isinstance(q, HasType) else 0)
+            for sub_query in q_list:
+                all_stmts = self._filter_stmts_by_query(sub_query, all_stmts)
+        elif isinstance(query, HasAgent):
+            all_stmts = self._filter_stmts_by_query(query, all_stmts)
+        else:
+            raise EntityError("Could not form a usable query from given "
+                              "constraints.")
+
+        self.statements = all_stmts.stmts
+        return self
+
+    def _filter_stmts_by_query(self, query, all_stmts):
+        if isinstance(query, HasAgent):
+            stmts = \
+                self._get_stmts_by_key_role((query.agent_id, query.namespace),
+                                            query.role)
+            if all_stmts:
+                return self._get_intersection(all_stmts, stmts)
+            else:
+                return stmts
+        elif isinstance(query, HasType):
+            self._filter_for_type(all_stmts, query.stmt_types[0])
+            return all_stmts
+        else:
+            logger.warning("Query {query} not handled.")
+            return all_stmts
 
     def sort_statements(self, stmts):
         stmts = sorted(stmts, key=lambda s: len(s.evidence),
@@ -110,12 +147,12 @@ class LocalQueryProcessor:
     def _get_agent_role(self, stmt, idx):
         if isinstance(stmt, (RegulateAmount, RegulateActivity,
                              Modification, Conversion, Gap, Gef)):
-            return 'SUBJ' if idx == 0 else 'OBJ'
+            return 'SUBJECT' if idx == 0 else 'OBJECT'
         elif isinstance(stmt, Complex):
-            return 'SUBJ'
+            return 'SUBJECT'
         elif isinstance(stmt, (ActiveForm, Translocation,
                                SelfModification)):
-            return 'AGENT'
+            return 'OTHER'
         else:
             assert False, stmt
 

--- a/bioagents/msa/local_query.py
+++ b/bioagents/msa/local_query.py
@@ -86,7 +86,7 @@ class LocalQueryProcessor:
             raise EntityError("Could not form a usable query from given "
                               "constraints.")
 
-        self.statements = all_stmts.stmts
+        self.statements = all_stmts
         return self
 
     def _filter_stmts_by_query(self, query, all_stmts):

--- a/bioagents/msa/local_query.py
+++ b/bioagents/msa/local_query.py
@@ -5,11 +5,12 @@ import requests
 from collections import defaultdict
 
 from indra.statements import *
-from indra.sources.indra_db_rest.query import Or, And, HasType, HasAgent
+from indra.sources.indra_db_rest.query import And, HasType, HasAgent
 from indra.assemblers.html.assembler import get_available_source_counts
 from indra.util.statement_presentation import _get_available_ev_source_counts
 
 from bioagents.msa.exceptions import EntityError
+
 
 logger = logging.getLogger(__name__)
 

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -121,7 +121,7 @@ class StatementQuery(object):
         for e in agents:
             self.agent_queries.append(self.new_agent(e, 'OTHER'))
 
-        if isinstance(self.agent_queries, EmptyQuery):
+        if not self.agent_queries:
             raise EntityError("Did not get any usable entity constraints!")
 
         self.verb = verb

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -7,6 +7,8 @@ import logging
 
 from collections import defaultdict
 
+from indra.sources import indra_db_rest
+from indra.sources.indra_db_rest.api import get_all_curations
 from indra.sources.indra_db_rest.query import *
 from indra.util.statement_presentation import group_and_sort_statements, \
     stmt_to_english, make_stmt_from_relation_key, make_standard_stats
@@ -30,16 +32,10 @@ logger = logging.getLogger('MSA')
 
 # We fetch curations if we have access to the DB, just to make this
 # more flexible, this can be turned off with an env variable
-if os.environ.get('INDRADB_ACCESS'):
-    try:
-        from indra_db import get_db
-        from indra_db.client.principal import curation
-        db = get_db('primary')
-        curs = curation.get_curations(db)
-        logger.info('Loaded %d curations in MSA' % len(curs))
-    except Exception as e:
-        curs = []
-else:
+try:
+    curs = get_all_curations()
+    logger.info('Loaded %d curations in MSA' % len(curs))
+except Exception as e:
     curs = []
 
 

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -105,9 +105,12 @@ class StatementQuery(object):
         If not provided, the following default list will be
         used: ['HGNC', 'FPLX', 'CHEBI', 'GO', 'MESH', !OTHER!', 'TEXT',
         '!NAME!'].
+    give_agents_role_none : bool
+        Toggle whether agents without a specified role are given role "OTHER" or
+        if their query is left with role None.
     """
-    def __init__(self, subj, obj, agents, verb, ent_type, params,
-                 valid_name_spaces=None):
+    def __init__(self, subj, obj, agents,  verb, ent_type, params,
+                 valid_name_spaces=None, give_agents_role_none=False):
         self.entities = {}
         self._ns_keys = valid_name_spaces if valid_name_spaces is not None \
             else ['HGNC', 'FPLX', 'CHEBI', 'GO', 'MESH', '!OTHER!', 'TEXT',
@@ -119,7 +122,10 @@ class StatementQuery(object):
         self.agent_queries.append(self.new_agent(obj, 'OBJECT'))
         self.agents = agents
         for e in agents:
-            self.agent_queries.append(self.new_agent(e, 'OTHER'))
+            if give_agents_role_none:
+                self.agent_queries.append(self.new_agent(e, None))
+            else:
+                self.agent_queries.append(self.new_agent(e, 'OTHER'))
 
         if not self.agent_queries:
             raise EntityError("Did not get any usable entity constraints!")
@@ -747,7 +753,7 @@ class BinaryUndirected(StatementFinder):
             logger.warning("Parameter `filter_agents` is not meaningful for "
                            "Binary queries.")
         return StatementQuery(None, None, [entity1, entity2], None, None,
-                              params)
+                              params, give_agents_role_none=True)
 
     def summarize(self):
         overrides = {'increaseamount': 'increase amount',

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -31,8 +31,7 @@ from bioagents.msa.exceptions import EntityError
 logger = logging.getLogger('MSA')
 
 
-# We fetch curations if we have access to the DB, just to make this
-# more flexible, this can be turned off with an env variable
+# We fetch curations if we an API key with sufficient permissions
 try:
     curs = get_curations()
     logger.info(f'Loaded {len(curs)} curations in MSA')

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -8,8 +8,9 @@ import logging
 from collections import defaultdict
 
 from indra.sources import indra_db_rest
-from indra.sources.indra_db_rest.api import get_all_curations
 from indra.sources.indra_db_rest.query import *
+from indra.sources.indra_db_rest.api import get_curations
+from indra.sources.indra_db_rest import IndraDBRestAPIError
 from indra.util.statement_presentation import group_and_sort_statements, \
     stmt_to_english, make_stmt_from_relation_key, make_standard_stats
 from bioagents.biosense.biosense import _read_kinases, _read_phosphatases, \
@@ -33,9 +34,13 @@ logger = logging.getLogger('MSA')
 # We fetch curations if we have access to the DB, just to make this
 # more flexible, this can be turned off with an env variable
 try:
-    curs = get_all_curations()
-    logger.info('Loaded %d curations in MSA' % len(curs))
+    curs = get_curations()
+    logger.info(f'Loaded {len(curs)} curations in MSA')
+except IndraDBRestAPIError as e:
+    logger.info(f"Loaded 0 curations in MSA (status: {e.status_code}).")
+    curs = []
 except Exception as e:
+    logger.info(f"Unexpected error loading curations: {e}")
     curs = []
 
 

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -973,7 +973,7 @@ class _Commons(StatementFinder):
         # agents held in common.
         processor = None
         for ag, ag_query in zip(self.query.agents,
-                                self.query.get_role_agent_queries(None)):
+                                self.query.get_role_agent_queries('OTHER')):
             if ag_query is None:
                 continue
 

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -295,8 +295,8 @@ class MSA_Module(Bioagent):
         else:
             return self.make_failure('BAD_INPUT')
         try:
-            stmts = get_statements_for_paper([('pmid', pmid)],
-                                             simple_response=True)
+            p = get_statements_for_paper([('pmid', pmid)])
+            stmts = p.statements
         except IndraDBRestAPIError as e:
             if e.status_code == 404 and 'Invalid or unavailable' in e.reason:
                 logger.error("Could not find pmid: %s" % e.reason)

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -16,7 +16,8 @@ from indra import has_config
 from indra.assemblers.sbgn import SBGNAssembler
 from indra.tools import assemble_corpus as ac
 
-from bioagents.msa.msa import MSA, EntityError
+from bioagents.msa.msa import MSA
+from bioagents.msa.exceptions import EntityError
 from bioagents import Bioagent
 
 if has_config('INDRA_DB_REST_URL') and has_config('INDRA_DB_REST_API_KEY'):

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -16,9 +16,10 @@ from indra import has_config
 from indra.assemblers.sbgn import SBGNAssembler
 from indra.tools import assemble_corpus as ac
 
+from bioagents import Bioagent
+
 from bioagents.msa.msa import MSA
 from bioagents.msa.exceptions import EntityError
-from bioagents import Bioagent
 
 if has_config('INDRA_DB_REST_URL') and has_config('INDRA_DB_REST_API_KEY'):
     from indra.sources.indra_db_rest import IndraDBRestAPIError, \

--- a/bioagents/tests/dtda_test.py
+++ b/bioagents/tests/dtda_test.py
@@ -405,7 +405,7 @@ class TestFindDiseaseTargets2(_IntegrationTest):
         protein = self.bioagent.get_agent(output.get('protein'))
         assert protein.name == 'KRAS'
         assert protein.db_refs['HGNC'] == '6407'
-        assert output.gets('prevalence') == '0.18', output
+        assert output.gets('prevalence') == '0.2', output
         assert output.gets('functional-effect') == 'ACTIVE', output
 
 
@@ -476,7 +476,7 @@ class TestFindTreatment2(_IntegrationTest):
 
     def check_response_to_message(self, output):
         assert output.head() == 'SUCCESS', output
-        assert output.gets('prevalence') == '0.18', output.get('prevalence')
+        assert output.gets('prevalence') == '0.2', output.get('prevalence')
         assert len(output.get('drugs')) == 0
 
 

--- a/bioagents/tests/dtda_test.py
+++ b/bioagents/tests/dtda_test.py
@@ -405,7 +405,8 @@ class TestFindDiseaseTargets2(_IntegrationTest):
         protein = self.bioagent.get_agent(output.get('protein'))
         assert protein.name == 'KRAS'
         assert protein.db_refs['HGNC'] == '6407'
-        assert output.gets('prevalence') == '0.2', output
+        assert float(output.gets('prevalence')) == 0.2, \
+            output.gets('prevalence')
         assert output.gets('functional-effect') == 'ACTIVE', output
 
 
@@ -476,7 +477,8 @@ class TestFindTreatment2(_IntegrationTest):
 
     def check_response_to_message(self, output):
         assert output.head() == 'SUCCESS', output
-        assert output.gets('prevalence') == '0.2', output.get('prevalence')
+        assert float(output.gets('prevalence')) == 0.2, \
+            output.gets('prevalence')
         assert len(output.get('drugs')) == 0
 
 

--- a/bioagents/tests/msa_test.py
+++ b/bioagents/tests/msa_test.py
@@ -771,6 +771,7 @@ def test_msa_custom_corpus_stmt_type():
                                  verb='activate')
     # Make sure we got the original statement back
     res_stmts = finder.get_statements()
+    assert res_stmts[0].__class__.__name__ == 'Activation'
     assert res_stmts[0].subj.name == 'z'
 
     finder = msa.find_mechanisms('to_target',
@@ -778,4 +779,5 @@ def test_msa_custom_corpus_stmt_type():
                                  verb='phosphorylate')
     # Make sure we got the original statement back
     res_stmts = finder.get_statements()
+    assert res_stmts[0].__class__.__name__ == "Phosphorylation"
     assert res_stmts[0].enz.name == 'x'


### PR DESCRIPTION
This PR makes updates needed to be compatible with the changes made in https://github.com/sorgerlab/indra/pull/1228. This PR also replaces a back-door access to the database with a service call that requires an API key.

I have resisted the temptation to make deeper changes to the MSA in this PR. The new INDRA client could likely allow for some cleaner implementations overall, however some other things are less obvious to convert so I have not taken the time to parse it all out. The MSA's current rather sophisticated implementation was in fact something of a precursor to the Query architecture, so the gains may be great. I estimate however they would require a great deal of effort.