### PR TITLE
Make MSA corpus configurable per instance

### DIFF
--- a/bioagents/msa/local_query.py
+++ b/bioagents/msa/local_query.py
@@ -2,8 +2,8 @@ import pickle
 import requests
 from collections import defaultdict
 from indra.statements import *
-from indra.assemblers.html.assembler import get_available_source_counts, \
-    _get_available_ev_source_counts
+from indra.assemblers.html.assembler import get_available_source_counts
+from indra.util.statement_presentation import _get_available_ev_source_counts
 
 
 def load_from_config(config_str):

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -21,6 +21,7 @@ from indra.assemblers.graph import GraphAssembler
 from indra.assemblers.english.assembler import english_join, \
     statement_base_verb, statement_present_verb, statement_passive_verb
 from indra.tools.assemble_corpus import filter_by_curation
+from indra.sources import indra_db_rest
 
 logger = logging.getLogger('MSA')
 
@@ -196,6 +197,7 @@ def _get_mesh_terms(context_agents, include_children=True):
 
 class StatementFinder(object):
     def __init__(self, *args, **kwargs):
+        self.idbr = kwargs.get('idbr_instance', indra_db_rest)
         self._block_default = kwargs.pop('block_default', True)
         self.mesh_terms = None
         self.query = self._regularize_input(*args, **kwargs)
@@ -1089,6 +1091,7 @@ class MSA(object):
     def find_mechanisms(self, method, *args, **kwargs):
         if method in self.__option_dict.keys():
             FinderClass = self.__option_dict[method]
+            kwargs['idbr_instance'] = self.idbr
             finder = FinderClass(*args, **kwargs)
             return finder
         else:

--- a/bioagents/msa/msa.py
+++ b/bioagents/msa/msa.py
@@ -197,7 +197,7 @@ def _get_mesh_terms(context_agents, include_children=True):
 
 class StatementFinder(object):
     def __init__(self, *args, **kwargs):
-        self.idbr = kwargs.get('idbr_instance', indra_db_rest)
+        self.idbr = kwargs.pop('idbr_instance', indra_db_rest)
         self._block_default = kwargs.pop('block_default', True)
         self.mesh_terms = None
         self.query = self._regularize_input(*args, **kwargs)

--- a/bioagents/msa/msa_module.py
+++ b/bioagents/msa/msa_module.py
@@ -58,7 +58,8 @@ class MSA_Module(Bioagent):
     signor_afs = _read_signor_afs()
 
     def __init__(self, *args, **kwargs):
-        self.msa = MSA()
+        corpus_config = os.environ.get('CWC_MSA_CORPUS')
+        self.msa = MSA(corpus_config=corpus_config)
         super(MSA_Module, self).__init__(*args, **kwargs)
         return
 


### PR DESCRIPTION
This PR moves `corpus_config` to be a constructor argument in the MSA making it possible to create corpus-specific instances during runtime. The default behavior in the integrated system is unchanged compared to the previous implementation, as the MSA module still uses the `CWC_MSA_CORPUS` env variable.