### PR TITLE
Fix source naming and escaping

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,10 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('**/setup.py') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - name: Set up Python 3.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.6
+        python-version: 3.8
     - name: Install dependencies
       run: |
         # Install Graphviz

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         sudo apt-get install libstdc++6 python3-dev graphviz libgraphviz-dev pkg-config
         sudo apt-get install graphviz
         # Tests use the web ontology but this is here as backup
-        bio_ontology_version=1.27
+        bio_ontology_version=1.30
         mkdir -p $HOME/.indra/bio_ontology/$bio_ontology_version
         wget -nv https://bigmech.s3.amazonaws.com/travis/bio_ontology/$bio_ontology_version/mock_ontology.pkl -O $HOME/.indra/bio_ontology/$bio_ontology_version/bio_ontology.pkl
         # Now do some regular pip installs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,11 +24,12 @@ jobs:
         sudo apt-get install libstdc++6 python3-dev graphviz libgraphviz-dev pkg-config
         sudo apt-get install graphviz
         # Tests use the web ontology but this is here as backup
-        mkdir -p $HOME/.indra/bio_ontology/1.11
-        wget -nv https://bigmech.s3.amazonaws.com/travis/bio_ontology/1.11/mock_ontology.pkl -O $HOME/.indra/bio_ontology/1.11/bio_ontology.pkl
+        bio_ontology_version=1.27
+        mkdir -p $HOME/.indra/bio_ontology/$bio_ontology_version
+        wget -nv https://bigmech.s3.amazonaws.com/travis/bio_ontology/$bio_ontology_version/mock_ontology.pkl -O $HOME/.indra/bio_ontology/$bio_ontology_version/bio_ontology.pkl
         # Now do some regular pip installs
         python -m pip install --upgrade pip
-        pip install numpy scipy sympy cython==0.23.5 nose lxml matplotlib pandas kappy==4.0.0 boto3 nose-timer coverage
+        pip install numpy scipy sympy cython==0.23.5 nose lxml matplotlib pandas<2.0.0 kappy==4.0.0 boto3 nose-timer coverage
         # Install Bionetgen
         wget --no-check-certificate "http://www.csb.pitt.edu/Faculty/Faeder/wp-content/uploads/2017/04/BioNetGen-2.2.6-stable_Linux.tar.gz" -O bionetgen.tar.gz -nv
         tar xzf bionetgen.tar.gz

--- a/bioagents/msa/local_query.py
+++ b/bioagents/msa/local_query.py
@@ -9,7 +9,7 @@ from indra.statements import *
 from indra.sources.indra_db_rest.query import And, HasType, HasAgent
 from indra.assemblers.html.assembler import get_available_source_counts
 from indra.util.statement_presentation import _get_available_ev_source_counts, \
-    _get_initial_source_counts
+    _get_initial_source_counts, internal_source_mappings
 
 from bioagents.msa.exceptions import EntityError
 
@@ -277,7 +277,12 @@ class Neo4jClient(QueryProcessorClient):
             if mkh not in self.source_counts:
                 self.source_counts[mkh] = _get_initial_source_counts()
             for source, num in source_counts.items():
-                self.source_counts[mkh][source] += num
+                # The dict from _get_initial_source_counts() contains the
+                # source names as they appear in indra_db while the
+                # source names in CoGEx are as they appear in INDRA,
+                # e.g. 'bel' (in CoGEx) instead of 'bel_lc' (indra_db).
+                mapped_source = internal_source_mappings.get(source, source)
+                self.source_counts[mkh][mapped_source] += num
         return stmts_from_json(stmt_jsons)
 
 

--- a/bioagents/msa/local_query.py
+++ b/bioagents/msa/local_query.py
@@ -271,8 +271,7 @@ class Neo4jClient(QueryProcessorClient):
         stmt_jsons = []
         for rel in relations:
             mkh = rel.data.get('stmt_hash')
-            stmt_json = json.loads(
-                rel.data.get('stmt_json').replace('\\\\', '\\').replace('\\\\', '\\'))
+            stmt_json = json.loads(_str_escaping(rel.data.get('stmt_json')))
             source_counts = json.loads(rel.data.get('source_counts'))
             stmt_jsons.append(stmt_json)
             if mkh not in self.source_counts:
@@ -307,3 +306,9 @@ preloads = MSA_CORPUS_PRELOADS.split(',') if MSA_CORPUS_PRELOADS else None
 
 resource_manager = ResourceManager(preloads=preloads)
 
+
+def _str_escaping(s: str) -> str:
+    """Remove double escaped characters and other escaping artifacts."""
+    return s.replace(
+        '\\\\', '\\').replace('\\\\', '\\').replace('\\{', '{').replace(
+        '\\}', '}')


### PR DESCRIPTION
This PR fixes the following issues:

- Long chemical names that had doubly escaped characters
- An inconsistency in source naming rooted in a difference in naming between indra db and indra.
- An f-string was missing a the `f"..."` prefix, this is now fixed
- A logger message has been updated to handle `None`